### PR TITLE
fixes to handle special characters in resource & collection names

### DIFF
--- a/modules/store.xql
+++ b/modules/store.xql
@@ -32,9 +32,9 @@ return
     util:catch("*",
         let $null :=
             if ($mime) then
-                xmldb:store($collection, $resource, $data, $mime)
+                xmldb:store(xmldb:encode-uri($collection), xmldb:encode-uri($resource), $data, $mime)
             else
-                xmldb:store($collection, $resource, $data)
+                xmldb:store(xmldb:encode-uri($collection), xmldb:encode-uri($resource), $data)
         return
             <message status="ok"/>,
         let $message :=

--- a/modules/upload.xql
+++ b/modules/upload.xql
@@ -74,7 +74,7 @@ let $name := request:get-uploaded-file-name("file[]")
 let $data := request:get-uploaded-file-data("file[]")
 return
     util:catch("*",
-        local:upload($collection, xmldb:encode($name), $data),
+        local:upload(xmldb:encode-uri($collection), xmldb:encode-uri($name), $data),
         <result>
            <name>{$name}</name>
            <error>{$util:exception-message}</error>


### PR DESCRIPTION
I noticed errors in eXide with filenames containing special characters
(e.g., spaces or Chinese characters).  I fixed this, primarily by using
xmldb:encode-uri() to handle passed parameters.  I tested the following
operations using resource & collection names containing special
characters:  1. Display collections (left hand pane) 2. Display
collections and resources (right hand pane) 3. Create collection 4.
Delete collection 5. Upload resource to db 6. Save editor contents to db
6. Delete resources  I tested while logged in as admin, as well as as
guest and a non-admin user to trigger error messages.  I confirmed that
the created resources & collections displayed correctly in oXygen and
the web admin client.  I did not test the effect of these changes on
EXPath repository behavior.
