### PR TITLE
first go at adding emmet (xml, html and css)

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -314,11 +314,12 @@ eXide.edit.Editor = (function () {
             $this.exec("quickFix", row);
         });
         
-        // var Emmet = require("ace/ext/emmet");
-        // net.loadScript("https://rawgithub.com/nightwing/emmet-core/master/emmet.js", function() {
-        //     Emmet.setCore(window.emmet);
-        //     $this.editor.setOption("enableEmmet", true);
-        // });
+         var Emmet = require("ace/ext/emmet");
+         //net.loadScript("https://rawgithub.com/nightwing/emmet-core/master/emmet.js", function() {
+         net.loadScript("$shared/resources/scripts/ace/emmet.js", function() {
+             Emmet.setCore(window.emmet);
+             $this.editor.setOption("enableEmmet", true);
+         });
 	};
 
     // Extend eXide.events.Sender for event support
@@ -363,7 +364,7 @@ eXide.edit.Editor = (function () {
         if (data && typeof data == "string") {
             session = new EditSession(data);
         } else if (type && type === "xquery") {
-            session = new EditSession("xquery version \"3.0\";\n1");
+            session = new EditSession("xquery version \"3.0\";\n");
         } else {
             session = new EditSession("");
         }
@@ -500,8 +501,8 @@ eXide.edit.Editor = (function () {
 		case "html":
 			var HtmlMode = require("eXide/mode/html").Mode;
             mode = new HtmlMode(this);
-			doc.$session.setMode(mode);
-            mode.$id = "html";
+			mode.$id = "html";
+            doc.$session.setMode(mode);
 			if (setMime)
 				doc.mime = "text/html";
 			break;


### PR DESCRIPTION
enable emmet style to run on `xml` and `html` files (closes wolfgangmm/eXide#37)

Additional changes required : 
#### in $shared/resources/scripts/ace/demo.js:

``` js
var onChangeMode = function(e, target) {
    var editor = target;
    if (!editor)
        return;
    var modeId = editor.session.$modeId;
    //var enabled = modeId && /css|less|sass|html|php/.test(modeId);
    var enabled = modeId && /xml|css|less|sass|html|php/.test(modeId);
    if (e.enableEmmet === false)
        enabled = false;
    if (enabled)
        editor.keyBinding.addKeyboardHandler(exports.commands);
    else
        editor.keyBinding.removeKeyboardHandler(exports.commands);
};
```
#### add emmet.js in $shared/resources/scripts/ace:

https://rawgithub.com/nightwing/emmet-core/master/emmet.js
#### Todo :

might be a good idea to add a preference option to ebable/disable emmet (e.g. switch to previous behavior with xml and html snippet)

Cheers, 
C.
