### PR TITLE
Support for extended permissions

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-project.version=2.0.3
+project.version=2.0.4

--- a/modules/collections.xql
+++ b/modules/collections.xql
@@ -117,11 +117,7 @@ declare function local:resources($collection as xs:string, $user as xs:string) {
                 where sm:has-access(xs:anyURI($path), "r")
                 order by $resource ascending
                 return
-                    let $permissions := 
-                        if ($isCollection) then
-                            xmldb:permissions-to-string(xmldb:get-permissions($path))
-                        else
-                            xmldb:permissions-to-string(xmldb:get-permissions($collection, $resource))
+                    let $permissions := sm:get-permissions(xs:anyURI($path))/sm:permission
                     let $owner := 
                         if ($isCollection) then
                             xmldb:get-owner($path)
@@ -148,7 +144,7 @@ declare function local:resources($collection as xs:string, $user as xs:string) {
                     return
                         <json:value json:array="true">
                             <name>{xmldb:decode-uri(if ($isCollection) then substring-after($resource, "/") else $resource)}</name>
-                            <permissions>{$permissions}</permissions>
+                            <permissions>{if($isCollection)then "c" else "-"}{string($permissions/@mode)}{if($permissions/sm:acl/@entries ne "0")then "+" else ""}</permissions>
                             <owner>{$owner}</owner>
                             <group>{$group}</group>
                             <last-modified>{$lastMod}</last-modified>

--- a/repo.xml
+++ b/repo.xml
@@ -13,6 +13,12 @@
     <permissions user="admin" password="" group="dba" mode="rw-rw-r--"/>
     <note>When upgrading, please make sure you also updated the shared-resources package to &gt; 0.3.5.</note>
     <changelog>
+        <change version="2.0.4">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Display of extended permissions in open/save dialogs</li>
+                <li>Editing of setuid, setgid and sticky bit permissions in Properties dialog</li>
+            </ul>
+        </change>
         <change version="2.0.3">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Added navigation shortcuts to quickly switch to buffer; navigate available commands</li>

--- a/src/resources.js
+++ b/src/resources.js
@@ -33,9 +33,9 @@ eXide.browse.ResourceBrowser = (function () {
 	
 	var columns = [
         {id: "name", name:"Name", field: "name", width: 180, formatter: nameFormatter, editor: Slick.Editors.Text},
-        {id: "permissions", name: "Permissions", field: "permissions", width: 70},
-        {id: "owner", name: "Owner", field: "owner", width: 70},
-        {id: "group", name: "Group", field: "group", width: 70},
+        {id: "permissions", name: "Permissions", field: "permissions", width: 80},
+        {id: "owner", name: "Owner", field: "owner", width: 65},
+        {id: "group", name: "Group", field: "group", width: 65},
         {id: "lastMod", name: "Last Modified", field: "last-modified", width: 140}
     ];
     
@@ -184,7 +184,7 @@ eXide.browse.ResourceBrowser = (function () {
             title: "Resource/collection properties",
 			modal: true,
 	        autoOpen: false,
-	        height: 340,
+	        height: 380,
 	        width: 460,
             buttons: {
                 "Cancel": function () { $(this).dialog("close"); },


### PR DESCRIPTION
Display and editing of setuid, setgid and sticky bits for permissions.

Also displays extended permissions in open/save dialogs, such that collections are prefixed 'c' and permissions with ACLs are postfixed '+'.

This change brings eXide inline with the permissions capabilities in the Dashboard Collections App and also the Java Admin Client.
