### PR TITLE
Update keybindings.js

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -31,7 +31,7 @@
     "extractVariable": ["Ctrl-Shift-E", "Command-Ctrl-E"],
     "gotoSymbol": ["Ctrl-Shift-U", "Command-Shift-U"],
     "openTab": ["Ctr-Alt-O", "Command-Ctrl-O"],
-    "toggleQueryResults": ["Ctrl-Shift-F12", "Command-Shift-F12"],
+    "toggleQueryResults": ["Ctrl-Shift-E", "Command-Shift-E"],
     "commandPalette": ["Ctr-Alt-K", "Command-Shift-K"],
     "findFiles": ["Ctrl-Alt-F", "Command-Option-F"]
 }


### PR DESCRIPTION
This (handy) key combo appears vacant. Because F12 is reached on a MacBook using two keys, fn and F12, the present key combo for toggleQueryResults requires four keys, which is rather unpractical.
