### PR TITLE
Update eXide.js

### DIFF
--- a/src/eXide.js
+++ b/src/eXide.js
@@ -457,7 +457,7 @@ eXide.app = (function() {
             						endOffset = startOffset + 10 - 1;
             						if (hitCount < endOffset)
             							endOffset = hitCount;
-            						eXide.util.message("Found " + hitCount + " in " + elem.getAttribute("elapsed") + "s");
+            						eXide.util.message("Query returned " + hitCount + " item(s) in " + elem.getAttribute("elapsed") + "s");
             						eXide.app.retrieveNext();
             					}
                                 break;


### PR DESCRIPTION
Queries do not only find, but construct, so "returned" is a better word than "found". The popup will have to be made a little wider. Perhaps the "s" on "item" should be made conditional on hitCount. 

Same pull request as #51.
