### PR TITLE
Directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project basedir="." default="all" name="eXide">
     <property file="local.build.properties"/>
     <property file="build.properties"/>
@@ -67,6 +66,7 @@
                 <file name="javascript-helper.js"/>
                 <file name="css-helper.js"/>
                 <file name="outline.js"/>
+                <file name="directory.js"/>
                 <file name="debuger.js"/>
                 <file name="codevalidator.js"/>
                 <file name="editor.js"/>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -357,12 +357,26 @@
             <div id="body">
                 <div id="layout-container">
                     <div class="layout layout-horizontal">
-                        <div id="outline-container" class="panel-west">
-                            <h3>Outline</h3>
-                            <div id="outline-body" class="content">
+                     <div id="outline-container" class="panel-west">
+                            <div id="tabs-outline-container">
+                                <ul id="tabs-outline"/>
+                            </div>
+
+                            <div id="outline-body">
                                 <div class="ace_scroller">
                                     <div class="ace_text-layer">
                                         <ul id="outline"/>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="directory-body">
+                                <div class="ace_scroller">
+                                    <div class="ace_text-layer">
+                                        <div class="tree">
+                                            <ul id="directory">
+                                                <li id="tree-root"/>
+                                            </ul>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -373,6 +387,7 @@
                                 <span title="Click to close outline"/>
                             </div>
                         </div>
+
                         <div class="layout-vertical">
                             <div class="main">
                                 <div id="tabs-container">

--- a/modules/collections.xql
+++ b/modules/collections.xql
@@ -50,7 +50,7 @@ declare function local:collections($root as xs:string, $child as xs:string,
                 <key>{xmldb:decode-uri(xs:anyURI($root))}</key>,
                 <writable json:literal="true">{if ($canWrite) then 'true' else 'false'}</writable>,
                 <addClass>{if ($canWrite) then 'writable' else 'readable'}</addClass>,
-            	if (exists($children)) then
+            	if (exists($children) ) then
                     local:sub-collections($root, $children, $user)
             	else
                 ()
@@ -147,6 +147,7 @@ declare function local:resources($collection as xs:string, $user as xs:string) {
                             <permissions>{if($isCollection)then "c" else "-"}{string($permissions/@mode)}{if($permissions/sm:acl/@entries ne "0")then "+" else ""}</permissions>
                             <owner>{$owner}</owner>
                             <group>{$group}</group>
+                            <key>{xmldb:decode-uri(xs:anyURI($path))}</key>
                             <last-modified>{$lastMod}</last-modified>
                             <writable json:literal="true">{$canWrite}</writable>
                             <isCollection json:literal="true">{$isCollection}</isCollection>

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -533,7 +533,7 @@ Sub level menu list items (undo style from Top level List Items)
     margin-right: 20px;
 }
 
-#tabs-container {
+#tabs-container, #tabs-outline-container {
     position: relative;
     /* Set it so we could calculate the offsetLeft */
     /* height: 145px; */
@@ -542,18 +542,18 @@ Sub level menu list items (undo style from Top level List Items)
     overflow: auto;
 }
 
-#tabs {
+#tabs, #tabs-outline {
 	list-style: none;
 	margin: 4px 4px 0 4px;
 	padding: 4px 0;
     overflow: none;
 }
 
-#tabs li {
+#tabs li, #tabs-outline li {
 	display: inline;
 }
 
-#tabs .tab {
+#tabs .tab, #tabs-outline .tab  {
     /* font: 12px 'Ubuntu Mono', 'Monaco','Menlo','Droid Sans Mono','Courier New',monospace; */
     font-size: 75%;
 	font-style: normal;
@@ -592,7 +592,7 @@ Sub level menu list items (undo style from Top level List Items)
     color: white;
 }
 
-#tabs .active {
+#tabs .active, #tabs-outline .active {
 	background: #E8E8E8;
 	color: #6e6e6e;
 }
@@ -1002,7 +1002,7 @@ Sub level menu list items (undo style from Top level List Items)
     height: 1.2em;
 }
 
-#outline-body {
+#outline-body, #directory-body {
     position: relative;
     -webkit-flex: auto;
     -moz-flex: auto;
@@ -1011,7 +1011,7 @@ Sub level menu list items (undo style from Top level List Items)
     width: 100%;
 }
 
-#outline-body .ace_scroller {
+#outline-body .ace_scroller, #directory-body .ace_scroller{
     position: absolute;
     top: 0;
     bottom: 0;
@@ -1021,16 +1021,20 @@ Sub level menu list items (undo style from Top level List Items)
     overflow-x: none;
 }
 
+#directory-body .ace_scroller{
+    overflow-x: auto;
+}
+
 #outline {
     font-family: 'Ubuntu Mono', 'Monaco','Menlo','Droid Sans Mono','Courier New',monospace;
-    line-height: 1.5em;
+    line-height: 0.9em;
     list-style: none;
     margin: 8px 4px 16px 4px;
     padding: 0;
     height: 100%;
     white-space: pre-wrap;
     /*  Added by CG  */
-    font-size : 85%;
+    font-size : 75%;
     /*  End Added */
     
 }
@@ -1457,4 +1461,83 @@ div#valueHighLight {
 .ui-button-icon-only .ui-icon[class*=" fa-"] {
     /* Bump it - jQuery UI is -8px */
     margin-left: -7px;
+}
+
+/* Tree */
+.tree {
+    min-height:20px;
+    padding:0px;
+    margin-bottom:20px;
+}
+
+.tree ul {
+    padding: 0px 0px 0px 20px;
+}
+
+.tree li {
+    list-style-type:none;
+    margin:0;
+    /*padding:13px 0px 0px 0px;*/
+    line-height: 0.9em;
+    font-size:10px;
+    position:relative
+}
+.tree li::before, .tree li::after {
+    content:'';
+    left:-20px;
+    position:absolute;
+    right:auto
+}
+.tree li.collection::before {
+    border-left:1px solid #999;
+}
+.tree li.collection::after {
+    border-top:1px solid #999;
+ }
+ .tree li.resource::before {
+    border-left:1px dotted #666;
+}
+.tree li.resource::after {
+    border-top:1px dotted #666;
+ }
+
+
+.tree li::before {
+    /*border-left:1px solid #999;*/
+    bottom:50px;
+    height:100%;
+    top:0;
+    width:1px
+}
+.tree li::after {
+    /*border-top:1px solid #999;*/
+    height:20px;
+    top:7px;
+    width:15px
+}
+.tree li span {
+
+    display:inline-block;
+    padding:3px 8px;
+    text-decoration:none
+}
+/*.tree li.parent_li>span {
+    cursor:pointer
+}*/
+.tree>ul>li::before, .tree>ul>li::after {
+    border:0
+}
+.tree li:last-child::before {
+    height:8px
+}
+/*.tree li.parent_li>span:hover, .tree li.parent_li>span:hover+ul li span {
+    background:#eee;
+    border:1px solid #94a0b4;
+    color:#000
+}*/
+.tree .collection span {
+    font-weight: bold;
+}
+.tree .resource span {
+    font-weight: normal;
 }

--- a/src/directory.js
+++ b/src/directory.js
@@ -1,0 +1,146 @@
+/*
+ *  eXide - web-based XQuery IDE
+ *  
+ *  Copyright (C) 2011 Wolfgang Meier
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+eXide.namespace("eXide.edit.Directory");
+
+/**
+ * XQuery directory view - Sublime style
+ * 
+ */
+eXide.edit.Directory = (function () {
+	
+	
+	Constr = function() {
+		this.currentDoc = null;
+        this.__activated = false; 
+        
+		init();
+	};
+	
+	function setFolderClass(d) {
+		return 'fa ' + (d.isCollection ? ('fa-folder' + (d.isOpen ? "-open" : "")): "") 
+	}
+	
+	function build(data) {
+		var sel = d3.select(this);
+		var fn = function(d) {
+			sel.selectAll('ul, span, i').remove()
+				
+			var li = sel.datum(d)
+						.attr('class', function(d) {return d.isCollection ? "collection" : "resource"})
+						.style('cursor','pointer')
+						.on('click', click)
+				
+			li
+				.append('i')
+				.attr('class', setFolderClass)
+			li
+				.append('span')
+				.text(function(d){return d.name})
+			
+			if(d.children && d.children.length){
+				sel
+					.append('ul')
+					.selectAll('li')
+					.data(d.children)
+					.enter()
+					.append('li')
+					.each(build)
+			}
+			
+		};
+
+		if(data) {
+			return fn(data.length ? data[0]: data)
+		}
+		d3.json("modules/collections.xql?root=" + (this.__data__.key || "/db") + "&view=r", function(error, data){
+			if(error)	{
+				return
+			}
+			var d = sel.datum()
+			d.isOpen = true;
+			d.isLoaded = true;
+			d.children = data.items.filter(function(i){return i.name != ".."})
+			fn(d)
+		} )
+	};
+	
+	function init() {
+		build.call(d3.select("#tree-root").node(), [{key:'/db',isCollection: true, isOpen:false, name:'db', isLoaded: false}])
+	};
+	
+	function toggleFolder(d) {
+		d.isOpen = !d.isOpen;
+		var sel = d3.select(this)
+		sel.select("i.fa").attr('class', setFolderClass)
+		if(d.isOpen) {
+		   return build.call(this)
+		}
+		sel.selectAll('ul').remove()
+	};
+	
+	
+	function loadFolder(d) {
+		build.call(this)
+	};
+	
+	function loadResource(d) {
+		eXide.app.$doOpenDocument({name :d.name, path: d.key, writable:d.writable});
+	};
+	
+	function click(d) {
+		d3.event.stopPropagation()
+		if(d.isCollection) {
+			if(d.isLoaded) {
+				return toggleFolder.call(this,d)
+			}
+			loadFolder.call(this,d)
+		}
+		else {
+			loadResource(d)
+		}
+	};
+	
+	Constr.prototype = {
+		toggle : function(state) {
+			if(state || state === false) {this.__activated = !!state}
+			else {this.__activated = !this.__activated};
+// 			d3.select(this.__rootSel).style("display", this.__activated ?  "block" : "none")
+			d3.select("#directory-body").style("position", this.__activated ? "relative" : "absolute")
+		},
+		
+		clearDirectory: function() {
+			$("#directory").empty();
+		},
+		
+//         filter: function(str) {
+//             var regex = new RegExp(str, "i");
+//             $("#directory li a").each(function() {
+//                 var item = $(this);
+//                 if (!regex.test(item.text())) {
+//                     item.hide();
+//                 } else {
+//                     item.show();
+//                 }
+//             });
+//         }
+	};
+	
+	return Constr;
+}());

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -913,8 +913,7 @@ eXide.app = (function(util) {
         },
         
         setTheme: function(theme) {
-            $("#outline-body").removeClass().addClass(theme.cssClass);
-            $("#results-body").removeClass().addClass(theme.cssClass);
+            $("#outline-body,#directory-body,#results-body ").removeClass().addClass(theme.cssClass);
         },
         
         updateStatus: function(doc) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -221,11 +221,14 @@ eXide.edit.Editor = (function () {
         menubar.editor = this;
         
 	    this.outline = new eXide.edit.Outline();
+	    this.directory = new eXide.edit.Directory();
 	    this.validator = new eXide.edit.CodeValidator(this);
 	    this.addEventListener("activate", this.outline, this.outline.updateOutline);
     	this.validator.addEventListener("validate", this.outline, this.outline.updateOutline);
 		this.addEventListener("close", this.outline, this.outline.clearOutline);
         
+       
+	    
 	    // Set up the status bar
 	    this.status = document.getElementById("error-status");
 	    $(this.status).click(function (ev) {
@@ -343,6 +346,23 @@ eXide.edit.Editor = (function () {
 	            $this.rebuildBuffersMenu();
 		    }
 		});
+		
+		 //Set up outline status bar
+		var outlineData = [{label: "outline", cls: "outline"},{label:'directory', cls:"directory"}]
+		d3.select("#tabs-outline").selectAll("li").data(outlineData)
+			.enter()
+			.append("li")
+				.append("a")
+				.attr("class", "tab")
+				.text(function(d,i){return d.label})
+				.on('click', function(d,i) {
+					d3.selectAll("#tabs-outline a.tab").classed("active", function(d,ii){return ii ==i})
+					outlineData.map(function(m,ii){return menubar.editor[m.cls].toggle(ii == i) })
+					})
+				.each(function(d,i){ // activate the first one
+					 menubar.editor[d.cls].toggle(i ===0 )
+					
+				})
 	};
 
     // Extend eXide.events.Sender for event support

--- a/src/outline.js
+++ b/src/outline.js
@@ -29,6 +29,7 @@ eXide.edit.Outline = (function () {
 	
 	Constr = function() {
 		this.currentDoc = null;
+        this.__activated = false;
         
         var self = this;
         $("#outline-filter").keyup(function() {
@@ -37,6 +38,13 @@ eXide.edit.Outline = (function () {
 	};
 	
 	Constr.prototype = {
+		
+		toggle : function(state) {
+			if(state || state === false) {this.__activated = !!state}
+			else {this.__activated = !this.__activated};
+// 			d3.select("#outline-body").style("display", this.__activated ? "block" : "none")
+			d3.select("#outline-body").style("position", this.__activated ? "relative" : "absolute")
+		},
 		
 		getTemplates: function (prefix) {
 			var re = new RegExp("^" + prefix);


### PR DESCRIPTION
# new feature : sublime-style collection/resource tree editor

I like the way sublime-text allows to browse resources directly in the editor, so thought about cloning this feature. This is a rapid first go. 

The pull request splits the outline editor into two : the classical `outline` + a new area for browsing database collections and resources called `directory`:

![exide-directory](https://cloud.githubusercontent.com/assets/1168053/4225452/d055ddaa-392d-11e4-9704-1f4c14c75203.png)

It is pretty straightforward to use it: click on collections to open/close them, click on resources to open them in the editor. 

Some thought for future development: 
- add drag and drop + rename features 
- find good way to display/modify resources permissions
- keep tree state for later sessions (and also when re-opening a collection)

Also added in the pull, some small fix to make the git features work again with version 2.1.0.

Cheers,
Christophe
