### PR TITLE
activate emmet for all potential types

### DIFF
--- a/src/xml-helper.js
+++ b/src/xml-helper.js
@@ -52,11 +52,13 @@ eXide.edit.XMLModeHelper = (function () {
     
     Constr.prototype.activate = function(doc) {
         this.menu.show();
-        if (doc.getSyntax() === "html" && this.parent.enableEmmet) {
-            this.editor.setOption("enableEmmet", true);
-        } else {
-            this.editor.setOption("enableEmmet", false);
-        }
+		this.editor.setOption("enableEmmet", this.parent.enableEmmet);
+// 		var syntax = doc.getSyntax();
+//         if ( syntax === "html" && this.parent.enableEmmet || syntax === 'xml') {
+//             this.editor.setOption("enableEmmet", true);
+//         } else {
+//             this.editor.setOption("enableEmmet", false);
+//         }
     };
     
     Constr.prototype.deactivate = function(doc) {


### PR DESCRIPTION
When emmet option is on, activate it for all potential types: xml, html, css, less,... not only for html.

A check against resource type is performed on demo.js (line 4387):

``` js
 var enabled = modeId && /xml|css|less|scss|sass|stylus|html|php/.test(modeId);
```
