### PR TITLE
add feature to display resources being edited

### DIFF
--- a/src/directory.js
+++ b/src/directory.js
@@ -122,7 +122,7 @@ eXide.edit.Directory = (function () {
 	function click(d) {
 		d3.event.stopPropagation()
 		if(d.isCollection) {
-			eXide.app.syncManager(d.key)
+			if(!d.isOpen) {eXide.app.syncManager(d.key)}
 			if(d.isLoaded) {
 				return toggleFolder.call(this,d)
 			}
@@ -145,9 +145,12 @@ eXide.edit.Directory = (function () {
 			$("#directory").empty();
 		},
 		reload : function (key) {
-			build.call(d3.select("[data-key='"+ key +"']"))
+			var sel = d3.select("[data-key='"+ key +"']")
+			if(sel.empty()) {return}
+			build.call(sel)
 		},
 		toggleEdit : function(key, state) {
+			
 			var sel = d3.select("[data-key='"+ key +"']")
 			if(sel.empty()) {return}
 			var d = sel.datum()

--- a/src/directory.js
+++ b/src/directory.js
@@ -122,10 +122,11 @@ eXide.edit.Directory = (function () {
 	function click(d) {
 		d3.event.stopPropagation()
 		if(d.isCollection) {
+			eXide.app.syncManager(d.key)
 			if(d.isLoaded) {
 				return toggleFolder.call(this,d)
 			}
-			eXide.app.syncManager(d.key)
+			
 			loadFolder.call(this,d)
 		}
 		else {

--- a/src/editor.js
+++ b/src/editor.js
@@ -510,6 +510,7 @@ eXide.edit.Editor = (function () {
             }
         }
 		this.$initDocument(doc);
+		this.directory.toggleEdit(this.activeDoc.getPath(), true)
 	};
 	
 	Constr.prototype.$initDocument = function (doc, setMime) {
@@ -648,6 +649,7 @@ eXide.edit.Editor = (function () {
 			$("#tabs a[title=\"" + this.activeDoc.path + "\"]").addClass("active");
 			this.editor.setSession(this.activeDoc.$session);
 			this.editor.resize();
+			this.directory.toggleEdit(doc.getPath(), false)
 			this.$triggerEvent("activate", [this.activeDoc]);
 		}
 	};


### PR DESCRIPTION
add a way to see on the view - which are the resources open in the editor (just a edit icon as on the screenshot below). Double-clicking in the tree on the resources already open will close them (it is too easy to open new resources now - too many tabs on the editor)

![screenshot from 2014-09-11 13 13 51](https://cloud.githubusercontent.com/assets/1168053/4233046/740a08be-39a5-11e4-92a2-06c326aca378.png)

That was really the last one for today ...
C.
