### PR TITLE
Fix outline being called too often

### DIFF
--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -1477,7 +1477,6 @@ div#valueHighLight {
 .tree li {
     list-style-type:none;
     margin:0;
-    display:table;
     /*padding:13px 0px 0px 0px;*/
     line-height: 0.9em;
     font-size:10px;

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -1477,6 +1477,7 @@ div#valueHighLight {
 .tree li {
     list-style-type:none;
     margin:0;
+    display:table;
     /*padding:13px 0px 0px 0px;*/
     line-height: 0.9em;
     font-size:10px;

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -132,8 +132,7 @@ eXide.app = (function(util) {
                     // dirty workaround to fix editor height
                     // var southStatus = localStorage.getItem("eXide.layout.south");
                     // $("#layout-container").layout().toggle("south");
-                    
-                    if (eXide.configuration && eXide.configuration.allowGuest) {
+                    if (eXide.configuration.allowGuest) {
                         $("#splash").fadeOut(400);
                     } else {
                         app.requireLogin(function() {
@@ -993,7 +992,8 @@ eXide.app = (function(util) {
             
             return {
                  branch: function(gitApp)   {
-                     if(!app.login || !app.login.isAdmin) {return}
+                     console.info('git.branch');
+                     if(!app.login.isAdmin) {return}   
                      $.ajax({ 
                         type: "GET",
                         url: gitUrl,

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -133,7 +133,7 @@ eXide.app = (function(util) {
                     // var southStatus = localStorage.getItem("eXide.layout.south");
                     // $("#layout-container").layout().toggle("south");
                     
-                    if (eXide.configuration.allowGuest) {
+                    if (eXide.configuration && eXide.configuration.allowGuest) {
                         $("#splash").fadeOut(400);
                     } else {
                         app.requireLogin(function() {
@@ -993,8 +993,7 @@ eXide.app = (function(util) {
             
             return {
                  branch: function(gitApp)   {
-                     console.info('git.branch');
-                     if(!app.login.isAdmin) {return}
+                     if(!app.login || !app.login.isAdmin) {return}
                      $.ajax({ 
                         type: "GET",
                         url: gitUrl,

--- a/src/outline.js
+++ b/src/outline.js
@@ -43,7 +43,10 @@ eXide.edit.Outline = (function () {
 			if(state || state === false) {this.__activated = !!state}
 			else {this.__activated = !this.__activated};
 // 			d3.select("#outline-body").style("display", this.__activated ? "block" : "none")
-			d3.select("#outline-body").style("position", this.__activated ? "relative" : "absolute")
+			d3.select("#outline-body").style("position", this.__activated ? "relative" : "absolute");
+            if(this.__activated && this.currentDoc) {
+                this.updateOutline(this.currentDoc)
+            }
 		},
 		
 		getTemplates: function (prefix) {
@@ -88,7 +91,7 @@ eXide.edit.Outline = (function () {
 			doc.functions = [];
             
             var helper = doc.getModeHelper();
-            if (helper != null) {
+            if (helper != null && this.__activated) {
                 helper.createOutline(doc, function() {
                     self.$outlineUpdate(doc);
                 });

--- a/src/outline.js
+++ b/src/outline.js
@@ -88,10 +88,10 @@ eXide.edit.Outline = (function () {
 		updateOutline: function(doc) {
             var self = this;
 			self.currentDoc = doc;
-			doc.functions = [];
             
             var helper = doc.getModeHelper();
             if (helper != null && this.__activated) {
+                doc.functions = [];
                 helper.createOutline(doc, function() {
                     self.$outlineUpdate(doc);
                 });

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -40,13 +40,16 @@ eXide.edit.XQueryModeHelper = (function () {
 		this.editor = this.parent.editor;
         this.xqDebugger = null;
         
-        // pre-compile regexp needed by this class
-    	this.funcDefRe = /declare\s+((?:%[\w\:\-]+(?:\([^\)]*\))?\s*)*)function\s+([^\(]+)\(/g;
-		this.varDefRe = /declare\s+(?:%\w+\s+)*variable\s+\$[^\s;]+/gm;
-		this.varRe = /declare\s+(?:%\w+\s+)*variable\s+(\$[^\s;]+)/;
-		// this.parseImportRe = /import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;/g;
-		this.parseImportRe = /\(:[^)]*:\)|(import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;)/g
+//      this.funcDefRe = /\(:[^)]*:\)|(declare\s+((?:%[\w\:\-]+(?:\([^\)]*\))?\s*)*)function\s+([^\(]+)\()/g;
+//      this.varDefRe = /\(:[^)]*:\)|(declare\s+(?:%\w+\s+)*variable\s+\$[^\s;]+)/gm;
+        this.funcDefRe = /\(:.*declare.+function.+:\)|(declare\s+((?:%[\w\:\-]+(?:\([^\)]*\))?\s*)*)function\s+([^\(]+)\()/g;
+        this.varDefRe = /\(:.*declare.+variable.+:\)|(declare\s+(?:%\w+\s+)*variable\s+\$[^\s;]+)/gm;
+        
+        this.varRe = /declare\s+(?:%\w+\s+)*variable\s+(\$[^\s;]+)/;
+        // this.parseImportRe = /import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;/g;
+        this.parseImportRe = /\(:[^)]*:\)|(import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;)/g
         this.moduleRe = /import\s+module\s+namespace\s+([^=\s]+)\s*=\s*["']([^"']+)["']\s*at\s+["']([^"']+)["']\s*;/;
+
 
 		// added to clean function name : 
         this.trimRe = /^[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]+|[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]+$/g;
@@ -1094,47 +1097,52 @@ eXide.edit.XQueryModeHelper = (function () {
 	}
     
     Constr.prototype.$parseLocalFunctions = function(text, doc) {
-		doc.functions = [];
-		
-		while (true) {
-			var funcDef = this.funcDefRe.exec(text);
-			if (funcDef == null) {
-				break;
-			}
-			var offset = this.funcDefRe.lastIndex;
-			var end = this.$findMatchingParen(text, offset);
-            var name = (funcDef.length == 3 ? funcDef[2] : funcDef[1]).replace(this.trimRe,"");
-            var status = funcDef.length == 3 ? funcDef[1] : "public";
-            var signature =  name + "(" + text.substring(offset, end) + ")"
-            if (status.indexOf("%private") !== -1)
-                status = "private";
-			doc.functions.push({
-				type: eXide.edit.Document.TYPE_FUNCTION,
-				name: name,
-                visibility: status,
-                signature: signature,
-                sort : "$$" + signature
-			});
-		}
-		var varDefs = text.match(this.varDefRe);
-		if (varDefs) {
-			for (var i = 0; i < varDefs.length; i++) {
-				var v = this.varRe.exec(varDefs[i]);
+        doc.functions = [];
+        
+        var match =  this.funcDefRe.exec(text), 
+            funcDef,
+            varDef;
+
+        while ((funcDef = match) != null) {
+            if(funcDef[1] != null ) {
+                var offset = this.funcDefRe.lastIndex;
+                var end = this.$findMatchingParen(text, offset);
+                var name = (funcDef.length == 4 ? funcDef[3] : funcDef[2]).replace(this.trimRe,"");
+                var status = funcDef.length == 4 ? funcDef[2] : "public";
+                var signature =  name + "(" + text.substring(offset, end) + ")"
+                if (status.indexOf("%private") !== -1) {status = "private";}
+                doc.functions.push({
+                    type: eXide.edit.Document.TYPE_FUNCTION,
+                    name: name,
+                    visibility: status,
+                    signature: signature,
+                    sort : "$$" + signature
+                });
+            };
+            match = this.funcDefRe.exec(text);
+        }
+
+        match =  this.varDefRe.exec(text);
+        while ((varDef = match) != null) {
+            if(varDef[1] != null ) {
+                var v = this.varRe.exec(varDef[1]);
                 var sort = v[1].substr(1).split(":");
                 sort.splice(1,0,":$");
                 var name = v[1];
                 if (name.substring(0, 1) == "$") {
                     name = name.substring(1);
                 }
-				doc.functions.push({
-					type: eXide.edit.Document.TYPE_VARIABLE,
-					name: name,
+                doc.functions.push({
+                    type: eXide.edit.Document.TYPE_VARIABLE,
+                    name: name,
                     sort: "$$" + sort.join("")
-				});
-			}
-		}
+                });
+            }
+            match = this.varDefRe.exec(text);
+        }
+
         this.$sortFunctions(doc);
-	}
+    }
 	
 	Constr.prototype.$findMatchingParen = function (text, offset) {
 		var depth = 1;

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -44,8 +44,10 @@ eXide.edit.XQueryModeHelper = (function () {
     	this.funcDefRe = /declare\s+((?:%[\w\:\-]+(?:\([^\)]*\))?\s*)*)function\s+([^\(]+)\(/g;
 		this.varDefRe = /declare\s+(?:%\w+\s+)*variable\s+\$[^\s;]+/gm;
 		this.varRe = /declare\s+(?:%\w+\s+)*variable\s+(\$[^\s;]+)/;
-		this.parseImportRe = /import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;/g;
-		this.moduleRe = /import\s+module\s+namespace\s+([^=\s]+)\s*=\s*["']([^"']+)["']\s*at\s+["']([^"']+)["']\s*;/;
+		// this.parseImportRe = /import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;/g;
+		this.parseImportRe = /\(:[^)]*:\)|(import\s+module\s+namespace\s+[^=]+\s*=\s*["'][^"']+["']\s*at\s+["'][^"']+["']\s*;)/g
+        this.moduleRe = /import\s+module\s+namespace\s+([^=\s]+)\s*=\s*["']([^"']+)["']\s*at\s+["']([^"']+)["']\s*;/;
+
 		// added to clean function name : 
         this.trimRe = /^[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]+|[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]+$/g;
         
@@ -1150,7 +1152,17 @@ eXide.edit.XQueryModeHelper = (function () {
 	}
 	
 	Constr.prototype.$parseImports = function(code) {
-		return code.match(this.parseImportRe);
+        var ret = [], 
+            re = this.parseImportRe,
+            match = re.exec(code);
+
+        // put Group capture in ret
+        while (match != null) {
+            if( match[1] != null ) {ret.push(match[1])};
+            match = re.exec(code);
+        }
+        return ret
+		// return code.match(this.parseImportRe);
 	}
 	
 	Constr.prototype.$resolveImports = function(doc, imports, onComplete) {


### PR DESCRIPTION
Outline can be pretty resource intensive in some case (e.g. with complex import tree) 
This pull request makes sure outline is called only when the outline view is active. With current behavior, outline view also is being updated when directory view is active. 
Cheers,
C.
