### PR TITLE
Allow dba to execute queries

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -69,9 +69,13 @@ declare function local:user-allowed() {
 };
 
 declare function local:query-execution-allowed() {
+    (
     config:get-configuration()/restrictions/@execute-query = "yes"
         and
     local:user-allowed()
+    )
+        or
+    xmldb:is-admin-user((request:get-attribute("org.exist.login.user"),request:get-attribute("xquery.user"), 'nobody')[1])
 };
 
 if ($exist:path eq '') then


### PR DESCRIPTION
The `@execute-query` restriction controls if non-dba users are allowed to execute XQuery code from within eXide. Previously if this restriction was set to `no`, even dba users were prevented from executing queries. This commit allows dba users to execute queries in the circumstance that `@execute-query` is set to `no`.
