### PR TITLE
modified store.xql to support storing of binary html files

### DIFF
--- a/modules/store.xql
+++ b/modules/store.xql
@@ -69,10 +69,13 @@ return
         try {
             let $isNew := not(util:binary-doc-available($path)) and not(doc-available($path))
             let $path :=
-                if ($mime) then
-                    xmldb:store($collection, $resource, $data, $mime)
+                if(util:binary-doc-available($path)) then
+                    xmldb:store-as-binary($collection, $resource, $data)
                 else
-                    xmldb:store($collection, $resource, $data)
+                    if ($mime) then
+                        xmldb:store($collection, $resource, $data, $mime)
+                    else
+                        xmldb:store($collection, $resource, $data)
             return (
                 if ($isNew) then
                     local:fix-permissions($collection, $resource)


### PR DESCRIPTION
This modification requires another existdb PR that adds the store-as-binary function to the xmldb module
