### PR TITLE
add snippets for output & html namespace decls

### DIFF
--- a/templates/xquery.snippets
+++ b/templates/xquery.snippets
@@ -57,6 +57,9 @@ snippet decns
 snippet decopt
 	declare option output:${1:method} "${2:html5}";
 
+snippet output
+    declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+
 snippet json
 	declare option output:method "json";
 	declare option output:media-type "application/json";
@@ -64,6 +67,9 @@ snippet json
 snippet html5
 	declare option output:method "html5";
 	declare option output:media-type "text/html";
+
+snippet html
+    declare namespace html="http://www.w3.org/1999/xhtml";
 
 snippet var
 	declare variable $${1:name} := ${2:()};


### PR DESCRIPTION
the existing "html5" and "json" snippets used the output namespace, but the snippets didn't include an output namespace declaration. also, i've added an (x)html namespace declaration; it's arguably at least as commonly used as the tei namespace declaration.
