### PR TITLE
fix rename bug with special characters

### DIFF
--- a/modules/collections.xql
+++ b/modules/collections.xql
@@ -528,7 +528,7 @@ return
             return
                 ($result[@status = "fail"], $result[1])[1]
         else if (exists($rename)) then
-            local:rename($collection, $rename)
+            local:rename($collection, xmldb:encode-uri($rename))
         else if (exists($deleteResource)) then
             local:delete(xmldb:encode-uri($collection), $deleteResource, $user)
         else if (exists($properties)) then


### PR DESCRIPTION
I discovered this bug when I accidentally renamed a file with a \ in the filename, and when I tried to rename the file again to remove the \, I got a "Invalid value for cast/constructor" error.  This fixes the problem by encoding the rename parameter before passing it to the rename function.
