### PR TITLE
[feature] Make "remember me" label clickable

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -512,7 +512,7 @@
                             </tr>
                             <tr>
                                 <td colspan="2">
-                                    <input type="checkbox" name="duration" value="P14D"/> Remember me for 2 weeks
+                                    <input type="checkbox" name="duration" value="P14D" id="remember-me"/> <label for="remember-me">Remember me for 2 weeks</label>
                         </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
It's convenient to be able to click on the label of an otherwise very small checkbox control.

I'm happy to apply this elsewhere; I think there are many similar controls whose labels could be made clickable.
