### PR TITLE
Use standard collection uri

### DIFF
--- a/pre-install.xql
+++ b/pre-install.xql
@@ -29,4 +29,4 @@ declare function local:mkcol($collection, $path) {
 
 (: store the collection configuration :)
 local:mkcol("/db/system/config", $target),
-xdb:store-files-from-pattern(concat("/system/config", $target), $dir, "*.xconf")
+xdb:store-files-from-pattern(concat("/db/system/config", $target), $dir, "*.xconf")


### PR DESCRIPTION
The non-standard uri worked, but better to use the standard one.
