### PR TITLE
Raise eXist dependency/@semver-max to “3.2.0”

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-project.version=2.3.1
+project.version=2.3.2

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,5 +2,5 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="@project.version@" spec="1.0">
     <title>eXide - XQuery IDE</title>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.4.0"/>
-    <dependency processor="http://exist-db.org" semver-min="3.0.0" semver-max="3.1.0"/>
+    <dependency processor="http://exist-db.org" semver-min="3.0.0" semver-max="3.2.0"/>
 </package>

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,11 @@
     <finish/>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="eXide" user="eXide" group="eXide" mode="0775"/>
     <changelog>
+        <change version="2.3.2">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Raise eXist dependency restrictions to allow compatibility with eXist 3.1</li>
+            </ul>
+        </change>
         <change version="2.3.1">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Add Adaptive Output mode handling for maps with a sequence of items as a value</li>


### PR DESCRIPTION
… to make compatible with 3.1. Closes #148.

Also, bump to 2.3.2 to prepare for a new tag and release.