### PR TITLE
Serialize strings when showing query results

### DIFF
--- a/modules/pretty-print.xql
+++ b/modules/pretty-print.xql
@@ -90,7 +90,7 @@ declare function pretty:pretty-print-xml($node as item(), $namespaces as xs:stri
                                 
                         }
                         </span>, '="',
-                        <span class="ace_string">{$nsDecl/@uri/string()}</span>,
+                        <span class="ace_string">{serialize($nsDecl/@uri/string())}</span>,
                         '"'
                     )
                 }
@@ -109,7 +109,7 @@ declare function pretty:pretty-print-xml($node as item(), $namespaces as xs:stri
                                 ),
                                 " "
                             )
-                        }">{$attr/string()}</span>, '"'
+                        }">{serialize($attr/string())}</span>, '"'
 					)
 				}
 				{
@@ -128,9 +128,9 @@ declare function pretty:pretty-print-xml($node as item(), $namespaces as xs:stri
 				}
 			</div>
 		case $text as text() return
-			<span class="ace_identifier">{$text}</span>
+			<span class="ace_identifier">{serialize($text)}</span>
 		case $comment as comment() return
-			<div class="ace_comment">&lt;!-- {$comment/string()} --&gt;</div>
+			<div class="ace_comment">&lt;!--{$comment/string()}--&gt;</div>
 		case $pi as processing-instruction() return
 			<div style="color: darkred">&lt;?{node-name($pi)}{if ($pi/string()) then " " || $pi/string() else ()}?&gt;</div>
 		default return
@@ -170,7 +170,7 @@ declare function pretty:pretty-print-adaptive($item as item()*, $namespaces as x
                         ),
                         " "
                     )
-                }">{$attr/string()}</span>, 
+                }">{serialize($attr/string())}</span>, 
                 '"'
             )
 	    case $map as map(*) return 
@@ -266,7 +266,7 @@ declare function pretty:pretty-print-adaptive($item as item()*, $namespaces as x
                 <span class="ace_paren ace_rparen">)</span>
 		    )
 	    case $string as xs:string | xs:untypedAtomic return
-	        <span class="ace_string">"{$string}"</span>
+	        <span class="ace_string">"{serialize($string)}"</span>
         case $qname as xs:QName return 
             (
                 <span class="ace_identifier">{"Q"}</span>,


### PR DESCRIPTION
Closes #161 

Now, the `&amp;` in`<a b="&amp;#34;c"/>` is returned intact rather than being returned as `<a b="&#34;c"/>`), whether the default Adaptive Output or XML Output is selected.

Also:

- `"&amp;"` returns the same instead of `"&"`
- `<x>&amp;</x>` returns the same instead of `<x>&</x>` 
- `<x xmlns="http://foo.org?a=1&amp;b=2"/>` returns the same, instead of `<x xmlns="http://foo.org?a=1&b=2"/>`

Tested this behavior in BaseX (which has implemented adaptive serialization) with queries like this:

```xquery
xquery version "3.1";

declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";

declare option output:method "adaptive";

"&amp;"
```