### PR TITLE
Bump to v2.3.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-project.version=2.3.2
+project.version=2.3.3

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,5 +2,5 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="@project.version@" spec="1.0">
     <title>eXide - XQuery IDE</title>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.4.0"/>
-    <dependency processor="http://exist-db.org" semver-min="3.0.0" semver-max="3.2.0"/>
+    <dependency processor="http://exist-db.org" semver-min="3.0.0"/>
 </package>

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,15 @@
     <finish/>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="eXide" user="eXide" group="eXide" mode="0775"/>
     <changelog>
+        <change version="2.3.3">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fix serialization of query results with strings containing escaped characters</li>
+                <li>Fix the column that "Navigate" > "Go to line" goes to</li>
+                <li>Improve download app to prevent expansion of XIncludes</li>
+                <li>Improve error reported when trying to run tests not stored in the database</li>
+                <li>Removed package's semver-max to ensure compatibility with all eXist 3.x releases</li>
+            </ul>
+        </change>
         <change version="2.3.2">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Raise eXist dependency restrictions to allow compatibility with eXist 3.1</li>


### PR DESCRIPTION
Removed package's `dependency/@semver-max` to ensure compatibility with 3.2.0 release and all future eXist 3.x releases