### PR TITLE
Restore setUID, setGID, and sticky bit settings

### DIFF
--- a/modules/collections.xql
+++ b/modules/collections.xql
@@ -373,7 +373,7 @@ declare %private function local:get-permissions($perms as xs:string) {
                 <label for="ox">execute</label>
             </td>
         </tr>
-        <!--tr>
+        <tr>
             <td>
                 { local:checkbox("us", substring($perms, 3, 1) = ("s", "S")) }
                 <label for="us">setuid</label>
@@ -386,7 +386,7 @@ declare %private function local:get-permissions($perms as xs:string) {
                 { local:checkbox("ot", substring($perms, 9, 1) = ("t", "T")) }
                 <label for="ot">sticky</label>
             </td>
-        </tr-->
+        </tr>
     </table>
 };
 


### PR DESCRIPTION
This feature was originally added in https://github.com/wolfgangmm/eXide/pull/44/commits/909a568a2bd8e35841042c84abe868d321d2a689 but was disabled in https://github.com/wolfgangmm/eXide/commit/154743b5c8cab5620834f0d57f686bad68057543 with the following comment:

> Comment out setuid, setgid bits in form until they are officially supported in eXist.

This was in November 2013. eXist 2.2 (released in November 2014) included the setUID, setGID, and sticky bit feature (see release notes at http://exist-db.org/exist/apps/wiki/blogs/eXist/eXist22). So I think it's okay to re-enable these checkboxes for setting setUID, setGID, and sticky bits.

I also tested the feature and confirmed that it works: setting these permissions in eXide is immediately reflected in the java admin client. And eXide correctly displays the permissions in question (though it always has).