### PR TITLE
Switch resource handling from name to key for deleteResource

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -470,7 +470,7 @@ eXide.browse.ResourceBrowser = (function () {
 		}
 		var resources = [];
 		for (var i = 0; i < selected.length; i++) {
-			resources.push(this.data[selected[i]].name);
+			resources.push(this.data[selected[i]].key);
 		}
 		var $this = this;
 		eXide.util.Dialog.input("Confirm Deletion", "Are you sure you want to delete the selected resources?",


### PR DESCRIPTION
As described at #185. So far, only fixes the deleteResource function. Ideally, this PR would be extended to change all resource functions to use `key` instead of `name`.