### PR TITLE
Force MSIE to use modern renderer

### DIFF
--- a/templates/existdb/templates/page.html
+++ b/templates/existdb/templates/page.html
@@ -4,6 +4,7 @@
         <title data-template="config:app-title">App Title</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <meta data-template="config:app-meta"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/> <!-- Force MSIE not to use compatibility mode -->
         <link rel="shortcut icon" href="$shared/resources/images/exist_icon_16x16.ico"/>
         <link rel="stylesheet" type="text/css" href="$shared/resources/css/exist-2.2.css"/>
         <link rel="stylesheet" type="text/css" href="resources/css/style.css"/>
@@ -53,7 +54,7 @@
                     </li>
                 </ul>
                 <div id="copyright">
-                    <p>Copyright eXist-db Project 2013</p>
+                    <p>Copyright eXist-db Project 2018</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In some conditions (corporate policies) the MSIE browser is forced by configuration  to use an old rendering engine.
By setting "X-UA-Compatible" we can allow the browser to use the latest available engine.

https://stackoverflow.com/questions/14611264/x-ua-compatible-content-ie-9-ie-8-ie-7-ie-edge#14611323