### PR TITLE
Fix Error 400 when displaying binary result

### DIFF
--- a/modules/session.xql
+++ b/modules/session.xql
@@ -48,7 +48,9 @@ declare function local:retrieve($num as xs:integer) as element() {
         </output:serialization-parameters>
     let $serialized :=
         serialize(
-            if ($cached-item instance of node() and $auto-expand-matches) then
+            if ($cached-item instance of xs:base64Binary) then
+                "[This placeholder represents a binary value, which eXide is unable to display.]"
+            else if ($cached-item instance of node() and $auto-expand-matches) then
                 util:expand($cached-item, "highlight-matches=both")
             else
                 $cached-item,


### PR DESCRIPTION
Before this PR, submitting a query such as:

```xquery
util:binary-doc("/db/apps/eXide/controller.xql")
```

... would store the binary resource in the session, and eXide would try to fetch this result (via `http://localhost:8080/exist/apps/eXide/results/1?output=adaptive&auto-expand-matches=false&indent=true`), which would return an Error 400 Bad Request:

```xml
<exception>
    <path>/db/apps/eXide/modules/session.xql</path>
    <message>exerr:ERROR Unable to encode string value: The underlying InputStream has been closed
        [at line 37, column 32, source: /db/apps/eXide/modules/session.xql] In function:
        local:retrieve(xs:integer) [104:24:/db/apps/eXide/modules/session.xql]</message>
</exception>
```

Now the following note is substituted for the value:

```
"[This placeholder represents a binary value, which eXide is unable to display.]"
```

Closes https://github.com/eXist-db/eXide/issues/171.