### PR TITLE
Ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - img=existdb/existdb:latest
   - img=existdb/existdb:release
   # - img= existdb/existdb:4.5.0
-  - img=evolvedbinary/exist-db:eXist-3.6.1-minimal
+
 
 before_install:
   - docker pull $img

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,19 @@ env:
   - img=existdb/existdb:release
   # - img= existdb/existdb:4.5.0
 
+jobs:
+  include:
+    # Define the release stage that runs semantic-release
+    - stage: release
+    - jdk: oraclejdk8
+    deploy:
+      provider: releases
+      api_key: $GH_TOKEN
+      file_glob: true
+      file: build/*
+      skip_cleanup: true
+      on:
+        tags: true
 
 before_install:
   - docker pull $img

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - oraclejdk11
+
+install:
+   - ant
+
+script: skip 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
-os:
-  - linux
-  - windows
+
 jdk:
   - oraclejdk8
   - oraclejdk11
@@ -9,4 +7,4 @@ jdk:
 install:
    - ant
 
-script: skip
+script: skip 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,11 @@ install:
 
 
 before_script:
+  # uninstall pre-installed eXide
   - docker exec exist-ci java -jar start.jar client --no-gui --xpath "repo:undeploy('http://exist-db.org/apps/eXide'), repo:remove('http://exist-db.org/apps/eXide')"
+  # upload new version with fake name
   - curl -T ./build/eXide-*.xar http://admin:@localhost:8080/exist/rest/db/tmp/eXide-ci.xar
+  # install new version
   - docker exec exist-ci java -jar start.jar client --no-gui --xpath "repo:install-and-deploy-from-db('/db/tmp/eXide-ci.xar')"
   - docker restart exist-ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,32 @@ jdk:
   - oraclejdk8
   - oraclejdk11
 
-install:
-   - ant
+services:
+  - docker
 
-script: skip 
+env:
+  - img=existdb/existdb:latest
+  - img=existdb/existdb:release
+  # - img= existdb/existdb:4.5.0
+  - img=evolvedbinary/exist-db:eXist-3.6.1-minimal
+
+before_install:
+  - docker pull $img
+  - docker create  --name exist-ci -p 8080:8080 $img
+  - docker start exist-ci
+  # exist needs time
+  - sleep 30
+  - docker ps
+
+install:
+  - ant
+
+
+before_script:
+  - docker exec exist-ci java -jar start.jar client --no-gui --xpath "repo:undeploy('http://exist-db.org/apps/eXide'), repo:remove('http://exist-db.org/apps/eXide')"
+  - curl -T ./build/eXide-*.xar http://admin:@localhost:8080/exist/rest/db/tmp/eXide-ci.xar
+  - docker exec exist-ci java -jar start.jar client --no-gui --xpath "repo:install-and-deploy-from-db('/db/tmp/eXide-ci.xar')"
+  - docker restart exist-ci
+
+
+script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-
+os:
+  - linux
+  - windows
 jdk:
   - oraclejdk8
   - oraclejdk11
@@ -7,4 +9,4 @@ jdk:
 install:
    - ant
 
-script: skip 
+script: skip

--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ eXide depends on the shared-resources eXpath-package which provides the ace edit
 ## Testing
 !! WIP !!
 We are working on improving the test coverage of eXide, and welcome contributions to help us improve both unit and integration tests. To add in-browser integrations tests contributor should open a pull request to [e2e-core](https://www.github.com/eXist-db/e2e-core).
+
+## Deployment
+New releases require a `.xar` file to be uploaded to `exist-db.org`'s public repo, and to Github releases. To trigger a new release simply add a tag in the form: 'vX.X.X' to the repo (where `X` corresponds to the semantic-version number of the new release). Tags can be added via CLI or the GitHub UI. Travis will automatically initiate the release and attach the xar once you added a tag. Either upload the `.xar` to public repo yourself, or post a not in hipchat. 

--- a/README.md
+++ b/README.md
@@ -1,58 +1,54 @@
 ![eXide logo](resources/images/logo.png)
 
-eXide - a web-based XQuery IDE
-==============================
+[![Build Status](https://travis-ci.com/eXist-db/eXide.svg?branch=develop)](https://travis-ci.com/eXist-db/eXide)
 
-eXide is a a web-based XQuery IDE built around the ace editor (http://ace.ajax.org/).
-It is tightly integrated with the eXist-db native XML database (http://exist-db.org).
+# eXide - a web-based XQuery IDE
+eXide is a a web-based XQuery IDE built around the [ace editor](http://ace.ajax.org/).
+It is tightly integrated with the [eXist-db native XML database](http://exist-db.org).
 
-Features
---------
-
-* XQuery function and variable completion (press Ctrl-Space or Opt-Space)
-* Outline view showing all functions and variables reachable from the current file
-* Powerful navigation (press F3 on a function call to see its declaration)
-* Templates
-* Background syntax checks for XQuery and XML
-* Database manager
-* Support for EXPath application packages: scaffolding, deployment...
-* And more ...
+## Features
+*   XQuery function and variable completion (press Ctrl-Space or Opt-Space)
+*   Outline view showing all functions and variables reachable from the current file
+*   Powerful navigation (press F3 on a function call to see its declaration)
+*   Templates
+*   Background syntax checks for XQuery and XML
+*   Database manager
+*   Support for EXPath application packages: scaffolding, deployment...
+*   And more ...
 
 eXide consists of two parts:
+1.  a javascript library for the client-side application
+2.  a set of XQuery scripts which are called via AJAX
 
-1. a javascript library for the client-side application
-2. a set of XQuery scripts which are called via AJAX
+## Dependencies
+eXide requires the shared-resources package in eXist-db. It should be installed by default unless you changed the build.
 
-Dependencies
-------------
-
-eXide requires the shared-resources package in eXist-db. It should be installed by default unless you changed
-the build.
-
-Building
---------
-
+## Building
 The latest version of eXide is included with eXist-db, though this might not be the newest version.
-You can install a newer or second version of eXide by deploying it directly into the database. This is
-also how development on eXide is done.
 
-To build eXide from scratch,
-you should first get eXist-db from SVN and build it (build.sh/build.bat). Next, clone eXide into a directory, e.g.:
+You can install a newer or second version of eXide by deploying it directly into the database. This is also how development on eXide is done.
 
-     git clone git://github.com/eXist-db/eXide.git eXideDev
-     cd eXideDev
-     git submodule update --init --recursive
+To build eXide from scratch:
+```bash
+git clone git://github.com/eXist-db/eXide.git
+cd eXide
+git submodule update --init --recursive
+```
 
-Next, call ant on the build.xml file in eXideDev:
+Next, call ant on the `build.xml` file in eXide:
+```bash
+ant
+```
 
-      ant
-
-You should now find a .xar file in the build directory:
-     
-     build/eXide-1.0.xar
-
-The .xar file is an installable package containing eXide. You can install this into any eXist 
+You should now find a `.xar` file in the `build/` directory:
+```    
+build/eXide-*.*.*.xar
+```
+The `.xar` file is an installable package containing eXide. You can install this into any eXist
 instance using the application repository manager in the dashboard.
 
-eXide depends on the shared-resources xar package which provides the ace editor files. If you install eXide
-via the dashboard, the dependency should be processed automatically.
+eXide depends on the shared-resources eXpath-package which provides the ace editor files. If you install eXide via the dashboard, the dependency should be processed automatically.
+
+## Testing
+!! WIP !!
+We are working on improving the test coverage of eXide, and welcome contributions to help us improve both unit and integration tests. To add in-browser integrations tests contributor should open a pull request to [e2e-core](https://www.github.com/eXist-db/e2e-core).

--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-project.version=2.4.6
+project.version=2.4.7-SNAPSHOT

--- a/build.xml
+++ b/build.xml
@@ -158,6 +158,7 @@
                 <exclude name=".git*"/>
                 <exclude name="*.tmpl"/>
                 <exclude name="*.properties"/>
+                <exclude name=".github/**"/>
             </fileset>
         </zip>
     </target>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="@project.version@" spec="1.0">
     <title>eXide - XQuery IDE</title>
-    <dependency package="http://exist-db.org/apps/shared" semver-min="0.4.0"/>
-    <dependency processor="http://exist-db.org" semver-min="3.3.0-SNAPSHOT"/>
+    <dependency package="http://exist-db.org/apps/shared" semver-min="0.8.0"/>
+    <dependency processor="http://exist-db.org" semver-min="4.0.0-SNAPSHOT"/>
 </package>


### PR DESCRIPTION
there are no unit tests for eXide, so this simply reproduces the build instructions in a clean environment including deployment into exist.

integration tests should go into the e2e-core repo for now.
the build uses some really funky stuff in dire need of updating.

but once there are test we simply need to call them in the script step. 