### PR TITLE
Fix XQuery snippets

### DIFF
--- a/templates/xquery.snippets
+++ b/templates/xquery.snippets
@@ -58,7 +58,7 @@ snippet decopt
 	declare option output:${1:method} "${2:html5}";
 
 snippet output
-    declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+	declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 
 snippet json
 	declare option output:method "json";
@@ -69,7 +69,7 @@ snippet html5
 	declare option output:media-type "text/html";
 
 snippet html
-    declare namespace html="http://www.w3.org/1999/xhtml";
+	declare namespace html="http://www.w3.org/1999/xhtml";
 
 snippet var
 	declare variable $${1:name} := ${2:()};


### PR DESCRIPTION
According to the Ace snippets documentation at https://cloud9-sdk.readme.io/docs/snippets#section-snippets, code in the snippets file must be preceded by a tab, not spaces. The spaces used in two snippets in the query.snippets file introduced in #100 were throwing off the snippet parser.

Test: In an XQuery editor pane, type "output" and hitting control-space to trigger the snippet generator. Before, the json snippet would appear instead of the expected output namespace declaration. With this PR, the expected output namespace declaration is returned.

Note: This does not fix the bug reported in #105, which still affects the current version of eXide.