### PR TITLE
report exception during upload replacing old util:exception-message 

### DIFF
--- a/modules/upload.xql
+++ b/modules/upload.xql
@@ -104,6 +104,6 @@ return
         upload:upload(xmldb:encode-uri($collection), encode-for-uri($path), $data),
         <result>
            <name>{$name}</name>
-           <error>{$util:exception-message}</error>
+           <error>{$err:description}</error>
         </result>
    )


### PR DESCRIPTION
Exception during upload are now reported properly replacing deprecated exception code (i guess).

I discovered this facing an issue uploading filename with colon inside. I will try to report this second point at right place because this is not only related to eXide...