### PR TITLE
encode collection/path and report proper exception if any

### DIFF
--- a/modules/upload.xql
+++ b/modules/upload.xql
@@ -101,10 +101,10 @@ let $path := ($pathParam, $name)[1]
 let $data := request:get-uploaded-file-data("file[]")
 return
     try {
-        upload:upload($collection, $path, $data)
+        upload:upload(xmldb:encode-uri($collection), encode-for-uri($path), $data)
     } catch * {
         <result>
            <name>{$name}</name>
-           <error>{$util:exception-message}</error>
+           <error>{$err:description}</error>
         </result>
     }


### PR DESCRIPTION
can store back again some filenames with colon or any other encoding requirement
  and 
error is now properly returned in json response on upload.xql POST (still to be displayed i guess)