### PR TITLE
Add handling for XSD 1.1 validation

### DIFF
--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,5 +2,5 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="@project.version@" spec="1.0">
     <title>eXide - XQuery IDE</title>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.8.3"/>
-    <dependency processor="http://exist-db.org" semver-min="4.0.0"/>
+    <dependency processor="http://exist-db.org" semver-min="4.3.0"/>
 </package>


### PR DESCRIPTION
The `validation:jaxv-report()` function needed for XSD 1.1 validation was added in https://github.com/eXist-db/exist/pull/1969 and released in eXist 4.3.0. 

As a result, this PR raises the minimum required version of eXist to 4.3.0 (from 4.0.0).

Since the jaxv function is only needed for XSD 1.1, we still call original jing function for other grammars.