### PR TITLE
Fix app generator

### DIFF
--- a/modules/deployment.xql
+++ b/modules/deployment.xql
@@ -229,7 +229,7 @@ declare function deploy:set-execute-bit($permissions as xs:string) {
 declare function deploy:copy-templates($target as xs:string, $source as xs:string, $userData as xs:string+, $permissions as xs:string) {
     let $null := deploy:mkcol($target, $userData, $permissions)
     return
-    if (exists(collection($source))) then (
+    if (xmldb:collection-available($source)) then (
         for $resource in xmldb:get-child-resources($source)
         let $targetPath := xs:anyURI(concat($target, "/", $resource))
         return (


### PR DESCRIPTION
After https://github.com/eXist-db/exist/pull/3349, the `fn:collection()` function no longer returns binary files. As a result, the expression `exists(collection($col))` here in eXide's app generator returns `false()` for a collection that contains only binary files. A more appropriate check for collection existence is `xmldb:collection-available()`. (This check isn’t really necessary here in eXide, but it doesn’t hurt either.)

Closes https://github.com/eXist-db/eXide/issues/251.