### PR TITLE
Sort resources numerically, so 3 < 22 < 111

### DIFF
--- a/modules/collections.xql
+++ b/modules/collections.xql
@@ -47,7 +47,7 @@ declare function local:sub-collections($root as xs:string, $children as xs:strin
         let $processChild :=
     		local:collections(concat($root, '/', $child), $child, $user)
 		where exists($processChild)
-		order by $child ascending
+		order by $child collation "http://www.w3.org/2013/collation/UCA?numeric=yes"
         return
             <children json:array="true">
 			    { $processChild }
@@ -91,7 +91,7 @@ declare function local:list-collection-contents($collection as xs:string, $user 
         return
             $r
     for $resource in ($subcollections, $resources)
-	order by $resource ascending
+	order by $resource collation "http://www.w3.org/2013/collation/UCA?numeric=yes"
 	return
 		$resource
 };
@@ -133,7 +133,7 @@ declare function local:resources($collection as xs:string, $user as xs:string) {
                     else
                         concat($collection, "/", $resource)
                 where sm:has-access(xs:anyURI($path), "r")
-                order by $resource ascending
+                order by $resource collation "http://www.w3.org/2013/collation/UCA?numeric=yes"
                 return
                     let $permissions := sm:get-permissions(xs:anyURI($path))/sm:permission
                     let $owner := $permissions/@owner/string()
@@ -434,7 +434,7 @@ declare function local:edit-properties($resources as xs:string*) {
                     <select name="owner">
                     {
                         for $user in $users
-                        order by $user
+                        order by $user collation "http://www.w3.org/2013/collation/UCA?numeric=yes"
                         return
                             <option value="{$user}">
                             {
@@ -453,7 +453,7 @@ declare function local:edit-properties($resources as xs:string*) {
                     <select name="group">
                     {
                         for $group in sm:list-groups()
-                        order by $group
+                        order by $group collation "http://www.w3.org/2013/collation/UCA?numeric=yes"
                         return
                             <option value="{$group}">
                             {


### PR DESCRIPTION
Before:

> <img width="120" alt="Screen Shot 2021-02-08 at 4 01 25 PM" src="https://user-images.githubusercontent.com/59118/107280903-f19f9100-6a26-11eb-9834-b150443bb3ee.png">

After:

> <img width="124" alt="Screen Shot 2021-02-08 at 4 02 50 PM" src="https://user-images.githubusercontent.com/59118/107281016-1e53a880-6a27-11eb-8e36-a3b37c76f8be.png">

For UCA and the `numeric` keyword, see https://www.w3.org/TR/xpath-functions-31/#uca-collations. eXist [gained support](https://github.com/eXist-db/exist/pull/1575) for UCA collations in 3.6.0—so there's no need to change the current eXist version dependency of >= 4.3.0.