### PR TITLE
[BUG] Ensure we're not testing an old version of eXide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - npm run build
 
 before_script:
-  - docker cp ./build/eXide-*.xar exist-ci:exist/autodeploy
+  - docker cp ./build/eXide-*.xar exist-ci:exist/autodeploy/111.xar
   - docker start exist-ci
   # exist needs time
   - sleep 30


### PR DESCRIPTION
This PR places the eXide xar for testing into the autodeploy folder as `111.xar` to ensure it is installed first before any other versions of eXide that might already be in the autodeploy folder. 

This is necessary because packages in autodeploy are installed in alphabetical order. If eXide-1.0.0 is already in autodeploy and the version you want to test is > 1.0.0, your new version won’t be tested, because autodeploy only installs the first version of a package it encounters.

For another repo that adopted the same strategy, see https://github.com/eXist-db/monex/blob/01959b10140c5dcebe44212c3d7413b72975fe36/.travis.yml#L29. Thanks to @duncdrum for the pointer!

This PR **will fail** CI with a "Slick is not defined" error, a bug hidden to CI before this PR, in eXide 3.0.0 (develop):

```
% npm run cypress

> exide@3.0.0 cypress
> cypress run


====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:    4.12.1                                                                             │
  │ Browser:    Electron 80 (headless)                                                             │
  │ Specs:      1 found (exide_spec.js)                                                            │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  exide_spec.js                                                                   (1 of 1)

  eXide
    1) should load
    ✓ should display editor (39ms)


  1 passing (5s)
  1 failing

  1) eXide
       should load:
     ReferenceError: The following error originated from your application code, not from Cypress.

  > Slick is not defined

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.

https://on.cypress.io/uncaught-exception-from-application
      at HTMLDocument.<anonymous> (http://localhost:8080/exist/apps/eXide/resources/scripts/eXide.min.js:282:39448)
      at c (http://localhost:8080/exist/apps/eXide/resources/scripts/jquery/jquery-1.9.1.min.js:3:7857)
      at Object.fireWith [as resolveWith] (http://localhost:8080/exist/apps/eXide/resources/scripts/jquery/jquery-1.9.1.min.js:3:8658)
      at Function.ready (http://localhost:8080/exist/apps/eXide/resources/scripts/jquery/jquery-1.9.1.min.js:3:3266)
      at HTMLDocument.H (http://localhost:8080/exist/apps/eXide/resources/scripts/jquery/jquery-1.9.1.min.js:3:695)
```