### PR TITLE
Ensure new version of eXide is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - npm run build
 
 before_script:
-  - docker cp ./build/eXide-*.xar exist-ci:exist/autodeploy
+  - docker cp ./build/eXide-*.xar exist-ci:exist/autodeploy/111.xar
   - docker start exist-ci
   # exist needs time
   - sleep 30


### PR DESCRIPTION
Packages in autodeploy are installed in alphabetical order. If eXide-1.0.0 is already in autodeploy and the version you want to test is > 1.0.0, your new version won’t be tested, because autodeploy only installs the first version of a package it encounters.

Rebase of #312 to test CI. Closes #312 