### PR TITLE
Add serialization prefs when opening, downloading XML documents from database

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -121,6 +121,18 @@ Drag a file on the editor to open its contents in a new tab.
 Use File > Manage > Upload Files > Upload Directory to upload
 entire directories and preserve their structure. Or drag and drop onto the Upload Files pane.
 
+## Run XQSuite tests
+
+Execute [XQSuite test suites](https://exist-db.org/exist/apps/doc/xqsuite) embedded in XQuery library modules by
+saving the module to the database (e.g., as `/db/test.xqm`) and selecting "XQuery > Run as test".
+
+## Support for EXPath Packages
+
+- Download packages stored in the database via "Application > Download app"
+- Synchronize your changes made on an application collection in the database to a directory on disk via "Application > Synchronize"
+- [Live reload](#Live-Reload) of resources in an application package
+- Upload and auto-install a package via "File > Manage > Upload" with the "Auto deploy uploaded .xar packages" checkbox selected
+
 ## Options for XML documents loaded from the database
 
 When loading XML documents from the database into an editor window, you can control whether indentation is automatically applied 
@@ -128,6 +140,30 @@ or not and whether XInclude elements are automatically expanded or not. Set this
 opening or downloading XML documents." The same preference applies to the download of XML documents via "File > Download" and
 the serialization of XML documents included in application packages via ["Application > Download app"](#Support-for-EXPath-Packages).
 By default, indentation is turned on and XInclude expansion is turned off.
+
+## Options for displaying query results
+
+To see the results of a query, hit the "Eval" button in eXide's toolbar. (The "Run" button opens the query in a new tab 
+and is only available for queries that have been saved to the database.) To automatically submit a query as you edit it, 
+select the "Live Preview" checkbox at the top of the query results window.
+
+eXide displays query results in groups of 10 (i.e., a query `1 to 100` would be split into 10 pages). Navigate through these 
+results with the `<<` and `>>` icons at the top of the query results window. To see all results in a single screen, surround your
+query with an array constructor: `array { 1 to 100 }`.
+
+When displaying query results, use the dropdown menu above the query results window to select a serialization method to apply
+to the results. The options available include all serialization options supported by eXist: Adaptive Output (eXide's default), 
+JSON, Text, XML, HTML5, XHTML, XHTML5, MicroXML, and  "Direct". In all but the last option, the selection overrides any 
+serialization declarations in a query's prolog, and the results are displayed as plain text. The "Direct" option allows the 
+serialization method to be set in the query, but the results are shown in the display window not as plain text but as the 
+browser would render them assuming HTML. 
+
+Besides controls for the serialization method, you can also control whether results are indented (pretty-printed) via the "Indent"
+checkbox just above the query results window. 
+
+When viewing the results of queries to eXist's full text index via `ft:query()`, you can automatically view the hits
+wrapped in `<exist:match>` elements by selecting the "Highlight Index Matches" checkbox above the query results window. This 
+simply applies the `util:expand()` function to the query's results.
 
 # Security
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,9 +1,22 @@
-# Feature Documentation
+# eXide Feature Documentation
+
+eXide is a web-based XQuery IDE built around the [ace editor](https://ace.c9.io/). It is tightly integrated with the [eXist-db native XML database](https://exist-db.org). 
+
+## Highlights
+
+*   XQuery function and variable completion (press Ctrl-Space or Opt-Space)
+*   Outline view showing all functions and variables reachable from the current file
+*   Powerful navigation (press F3 on a function call to see its declaration)
+*   Templates and snippets
+*   Background syntax checks for XQuery and XML
+*   Database manager
+*   Support for EXPath application packages: scaffolding, deployment...
+*   And more ...
 
 ## Validation as you type
 
-eXide constantly validates code while you edit an XQuery. It combines a client-side XQuery parser 
-(<a href="https://github.com/wcandillon/xqlint">xqlint</a>) with
+eXide constantly validates code while you edit an XQuery. It combines a client-side XQuery parser,
+[xqlint](https://github.com/wcandillon/xqlint), with
 the errors reported by the eXist-db server.
 
 Validation on the server finds errors across all related modules,
@@ -23,13 +36,13 @@ A popup will be shown if there's more than one possible completion. Otherwise th
 
 As an alternative to the `tab` key, you can also press `Ctrl-Space`, `Cmd-Space` or
 `Option-Space` (Mac). Unlike `tab`, this will also work if the cursor is placed in white space
-or inside the prefix or namespace declarations of an <i>import module</i> or <i>declare namespace</i> expression.
+or inside the prefix or namespace declarations of an *import module* or *declare namespace* expression.
 
 ## Code Snippets
 
 Snippets are triggered by pressing
-`tab` after typing a known keyword. For example, to create a new XQuery function, type
-<i>fun</i> and press `tab`. A snippet may have one or more parameters to change: after insertion, 
+the `tab` key after typing a known keyword. For example, to create a new XQuery function, type
+*fun* and press `tab`. A snippet may have one or more parameters to change: after insertion, 
 the function name will be selected so you can edit it. Pressing `tab` will move to the next snippet parameter.
 Press `ESC` when you are done editing parameters.
 
@@ -41,10 +54,8 @@ to edit them. All snippet files reside in the templates collection inside the eX
 
 ## Refactoring
 
-Extract function or variable from selected block
-
 When writing XQuery code, one often ends up with long FLWOR expressions or markup with lots of enclosed XQuery.
-In good functional style you want to clean this up and extract code into functions. eXide 2.0 simplifies this by
+In good functional style you want to clean this up and extract code into functions. eXide simplifies this by
 providing refactorings for functions and variables.
 
 To extract code into a function, select it in the editor (the block has to be syntactically valid) and choose
@@ -73,8 +84,7 @@ Press `ESC` when you are done.
 eXide continually parses the XQuery code while you type and displays an error or warning icon in the gutter of
 the corresponding line. But instead of just complaining, eXide is able to suggest a quick fix for some types
 of warnings or errors. To see if a quick fix is available, click on the icon or press the quick fix shortcut
-(`Ctrl-Shift-Q` or `Command-Ctrl-Q`) to see a list of suggestions. Quick fixes are available for
-(we'll add more over time):
+(`Ctrl-Shift-Q` or `Command-Ctrl-Q`) to see a list of suggestions. Quick fixes are available for:
 
 * undeclared namespaces
 * calls to unknown functions
@@ -91,12 +101,12 @@ To quickly navigate to any known function or variable declaration, press `Ctrl-S
 or `Cmd-Shift-U` and choose a target from the popup. Btw, within the popup, just type to
 limit the displayed list to items containing the typed string.
 
+eXide displays a list of all XQuery functions defined and imported in the "outline" pane to the left
+of the query editor.
+
 ## Module Import
 
-There are two ways to quickly import another XQuery module into the current code:
-
-1. Choose the "Import Module" dialog from the menu or type `F4`
-2. Create an "import module" statement (type "import" and press `tab`) and enter the prefix. When you are within the quotes for 
+Create an "import module" statement (type "import" and press `tab`) and enter the prefix. When you are within the quotes for 
 the namespace URI, press `Ctrl-Space` or `Cmd-Space` to call autocomplete. This should pop up any module currently stored in the db which matches the prefix you entered.
 
 ## Live Reload
@@ -105,20 +115,22 @@ When developing an XQuery application, enable *Live Reload* and the browser
 tab or window containing the application's web page will automatically reload whenever
 you save a resource belonging to the app's package.
 
-Just start the app via the `Application/Run app` menu entry and check
+Just start the app via the `Application > Live Reload` menu entry and check
 *activate live reload*.
 
-Note: due to browser security restrictions, live reload will only work if the app window has been
-opened from within eXide, not via the dashboard. A web page cannot control other windows unless it
+Then follow the instructions to enable live reload. Due to browser security restrictions, Live Reload
+will only work if the app window has been
+opened from within eXide, not via the Dashboard. A web page cannot control other windows unless it
 created them.
 
 ## Drop Files
 
-Drag a file on the editor to open its contents in a new tab.
+Drag a file on the editor to open its contents in a new tab. The new tab will not have the original file's name, 
+but you can provide a name via "File > Save".
 
 ## Directory Uploads
 
-Use File > Manage > Upload Files > Upload Directory to upload
+Use "File > Manage > Upload Files > Upload Directory" to upload
 entire directories and preserve their structure. Or drag and drop onto the Upload Files pane.
 
 ## Run XQSuite tests
@@ -184,14 +196,14 @@ within the eXide app collection:
 </configuration>
 ```
 
-* The **execute-query=yes|no** attribute controls if non-dba users are allowed to execute XQuery code 
+* The `execute-query=yes|no` attribute controls if non-dba users are allowed to execute XQuery code 
 from within eXide.
-* **guest=yes|no**: if set to "no", the default guest user will not be able to log in. eXide will
+* `guest=yes|no`: if set to "no", the default guest user will not be able to log in. eXide will
     thus always show a login window before the editor is loaded - unless you already provided credentials during
     a previous, still valid session.
-* One or more **<deny>** elements can be specified to block access to particular collections, even if the user
+* One or more `<deny>` elements can be specified to block access to particular collections, even if the user
     has the appropriate database permissions to see those collections.
 
 The additional security checks are done on the server, so hacking the client won't be fruitful. However, if you use
-the <deny> feature, **you must make sure** that access to eXide's own collection is denied as well.
+the `<deny>` feature, **you must make sure** that access to eXide's own collection is denied as well.
 If not, logged in users could simply change eXide's code.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -121,6 +121,14 @@ Drag a file on the editor to open its contents in a new tab.
 Use File > Manage > Upload Files > Upload Directory to upload
 entire directories and preserve their structure. Or drag and drop onto the Upload Files pane.
 
+## Options for XML documents loaded from the database
+
+When loading XML documents from the database into an editor window, you can control whether indentation is automatically applied 
+or not and whether XInclude elements are automatically expanded or not. Set this preference in "Edit > Preferences > When 
+opening or downloading XML documents." The same preference applies to the download of XML documents via "File > Download" and
+the serialization of XML documents included in application packages via ["Application > Download app"](#Support-for-EXPath-Packages).
+By default, indentation is turned on and XInclude expansion is turned off.
+
 # Security
 
 Keeping eXide installed on a production server can pose a security risk. eXide fully respects eXist's security model, 

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -171,10 +171,6 @@
                                     <a href="#" id="menu-navigate-definition" data-command="gotoDefinition">
                                         <span class="fa fa-crosshairs"/>Go to definition</a>
                                 </li>
-                                <!--li>
-                                    <a href="#" id="menu-navigate-modules" data-command="findModule">
-                                        <span class="fa fa-plus"/>Go to/import module</a>
-                                </li-->
                                 <li>
                                     <a href="#" id="menu-navigate-info" data-command="functionDoc">
                                         <span class="fa fa-info"/>Function doc</a>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -585,6 +585,7 @@
                 <div id="preferences-dialog">
                     <form>
                         <fieldset>
+                            <legend>Editor</legend>
                             <ol>
                                 <li>
                                     <select id="theme" name="theme">
@@ -666,7 +667,7 @@
                                         <option value="4">4 spaces</option>
                                         <option value="8">8 spaces</option>
                                     </select>
-                                    <label for="indent-size">indent size:</label>
+                                    <label for="indent-size">Indent size:</label>
                                 </li>
                                 <li>
                                     <select name="soft-wrap">
@@ -684,6 +685,19 @@
                                 <li>
                                     <input type="checkbox" name="emmet"/>
                                     <label for="emmet">Enable emmet in HTML mode:</label>
+                                </li>
+                            </ol>
+                        </fieldset>
+                        <fieldset>
+                            <legend>When opening or downloading XML documents</legend>
+                            <ol>
+                                <li>
+                                    <input type="checkbox" name="indent-on-load" id="indent-on-load"/>
+                                    <label for="indent-on-load">Indent:</label>
+                                </li>
+                                <li>
+                                    <input type="checkbox" name="expand-xincludes-on-load" id="expand-xincludes-on-load"/>
+                                    <label for="expand-xincludes-on-load">Expand XIncludes:</label>
                                 </li>
                             </ol>
                         </fieldset>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -796,9 +796,9 @@
             <div id="dialog-startup">
                 <h1>Getting Help</h1>
                 <p>
-                    eXide 2.0 has many new features. Make sure you read the
+                    eXide has many features. Make sure you read the
                     <a href="https://github.com/eXist-db/eXide#readme" target="_new">documentation</a>
-                to understand code completion, refactorings and keyboard shortcuts.</p>
+                to understand code completion, refactorings, and keyboard shortcuts.</p>
             </div>
             <div id="dialog-git-checkout">
                 <p>Checkout git working directory to another branch</p>

--- a/keybindings.js
+++ b/keybindings.js
@@ -17,7 +17,6 @@
     "gotoDefinition": ["F3", "F3"],
     "searchIncremental": ["Ctrl-F", "Command-F"],
     "searchReplace": ["Ctrl-Shift-F", "Command-Shift-F"],
-    "findModule": ["F4", "F4"],
     "indentOrParam": ["Tab", "Tab"],
     "escape": ["Esc", "Esc"],
     "dbManager": ["Ctrl-Shift-M", "Command-Shift-M"],

--- a/modules/deployment.xql
+++ b/modules/deployment.xql
@@ -640,7 +640,6 @@ let $collection :=
     else
         repo:get-root() || $target
 let $info := request:get-parameter("info", ())
-let $deploy := request:get-parameter("deploy", ())
 let $download := request:get-parameter("download", ())
 let $expand-xincludes := request:get-parameter("expand-xincludes", "false") cast as xs:boolean
 let $indent := request:get-parameter("indent", "false") cast as xs:boolean

--- a/modules/deployment.xql
+++ b/modules/deployment.xql
@@ -641,8 +641,8 @@ let $collection :=
         repo:get-root() || $target
 let $info := request:get-parameter("info", ())
 let $download := request:get-parameter("download", ())
-let $expand-xincludes := request:get-parameter("expand-xincludes", "false") cast as xs:boolean
-let $indent := request:get-parameter("indent", "false") cast as xs:boolean
+let $expand-xincludes := request:get-parameter("expand-xincludes", ()) cast as xs:boolean
+let $indent := request:get-parameter("indent", ()) cast as xs:boolean
 let $expathConf := if ($collection) then xmldb:xcollection($collection)/expath:package else ()
 let $repoConf := if ($collection) then xmldb:xcollection($collection)/repo:meta else ()
 let $abbrev := request:get-parameter("abbrev", ())

--- a/modules/load.xql
+++ b/modules/load.xql
@@ -20,8 +20,6 @@ xquery version "3.0";
 
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
 
-declare option exist:serialize "indent=yes expand-xincludes=no";
-
 declare function local:get-run-path($path) {
     let $appRoot := repo:get-root()
     return
@@ -37,6 +35,8 @@ declare function local:get-run-path($path) {
 
 let $path := request:get-parameter("path", ())
 let $download := request:get-parameter("download", ())
+let $indent := request:get-parameter("indent", true()) cast as xs:boolean
+let $expand-xincludes := request:get-parameter("expand-xincludes", false()) cast as xs:boolean
 let $mime := xmldb:get-mime-type($path)
 let $isBinary := util:is-binary-doc($path)
 (: Disable betterFORM filter :)
@@ -55,11 +55,19 @@ return
             return
                 response:stream-binary($data, $mime, ())
         else
-            let $doc := doc($path)
-            return
-                if ($doc) then
-                    $doc
-                else
-                    response:set-status-code(404)
+            if (doc-available($path)) then
+                (
+                    (: workaround until https://github.com/eXist-db/exist/issues/2394 is resolved :)
+                    util:declare-option(
+                        "exist:serialize", 
+                        "indent=" 
+                            || (if ($indent) then "yes" else "no")
+                            || " expand-xincludes=" 
+                            || (if ($expand-xincludes) then "yes" else "no")
+                    ),
+                    doc($path)
+                )
+            else
+                response:set-status-code(404)
     else
         response:set-status-code(404)

--- a/src/deployment.js
+++ b/src/deployment.js
@@ -210,45 +210,6 @@ eXide.edit.PackageEditor = (function () {
 	
     // Extend eXide.events.Sender for event support
     eXide.util.oop.inherit(Constr, eXide.events.Sender);
-	
-	/**
-	 * Deploy the current application package.
-	 */
-	Constr.prototype.deploy = function(collection) {
-		var $this = this;
-        var msg =
-            "<p>Note: target has to be different from the source package or it will be overwritten!</p>" +
-            "<p><label for=\"target\">Target collection:</label>" +
-            "<input id=\"deployment-target\" type=\"text\" name=\"target\" value=\"" + collection + 
-                "-test\"size=\"30\"/></p>";
-        eXide.util.Dialog.input("Deploy", msg, function() {
-            var target = $("#deployment-target").val();
-            if (target === "")
-                target = collection;
-			$.ajax({
-				url: "modules/deployment.xql",
-				type: "POST",
-				dataType: "json",
-				data: { "collection": collection, "target": target, "deploy": "true" },
-				success: function (data) {
-					var url = location.protocol + "//" + location.hostname + ":" + location.port + "/exist/apps/" + data + "/";
-					eXide.util.Dialog.message("Application Deployed", "<p>The application has been deployed. On a standard " +
-							"installation the following link should open it:</p>" +
-							"<center><a href=\"" + url + "\" target=\"_new\">" + url + "</a></center>");
-                    $this.$triggerEvent("change", collection);
-				},
-				error: function (xhr, status) {
-					if (xhr.status == 404) {
-						eXide.util.error("Deployment failed. The document currently opened in the editor " +
-								"should belong to an application package.");
-					} else {
-						eXide.util.Dialog.warning("Deployment Error", "<p>An error has been reported by the database:</p>" +
-							"<p>" + xhr.responseText + "</p>");
-					}
-				}
-			});
-        });
-	};
 
     Constr.prototype.download = function (collection) {
         window.location.href = "modules/deployment.xql?download=true&collection=" + encodeURIComponent(collection);

--- a/src/deployment.js
+++ b/src/deployment.js
@@ -212,7 +212,9 @@ eXide.edit.PackageEditor = (function () {
     eXide.util.oop.inherit(Constr, eXide.events.Sender);
 
     Constr.prototype.download = function (collection) {
-        window.location.href = "modules/deployment.xql?download=true&collection=" + encodeURIComponent(collection);
+        var indentOnLoad = $("#indent-on-load").is(":checked");
+        var expandXIncludesOnLoad = $("#expand-xincludes-on-load").is(":checked");
+		window.location.href = "modules/deployment.xql?download=true&collection=" + encodeURIComponent(collection) + "&indent=" + indentOnLoad + "&expand-xincludes=" + expandXIncludesOnLoad;
     };
     
 	/**

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -291,6 +291,8 @@ eXide.app = (function(util) {
 
 		$doOpenDocument: function(resource, callback, reload) {
 			resource.path = util.normalizePath(resource.path);
+            var indentOnLoad = $("#indent-on-load").is(":checked");
+            var expandXIncludesOnLoad = $("#expand-xincludes-on-load").is(":checked");
             var doc = editor.getDocument(resource.path);
             if (doc && !reload) {
                 editor.switchTo(doc);
@@ -300,8 +302,9 @@ eXide.app = (function(util) {
                 return true;
             }
 			$.ajax({
-				url: "modules/load.xql?path=" + resource.path,
+				url: "modules/load.xql",
 				dataType: 'text',
+				data: { "path": resource.path, "indent": indentOnLoad, "expand-xincludes": expandXIncludesOnLoad },
 				success: function (data, status, xhr) {
                     if (reload) {
                         editor.reload(data);
@@ -446,12 +449,14 @@ eXide.app = (function(util) {
         },
         
 		download: function() {
+            var indentOnLoad = $("#indent-on-load").is(":checked");
+            var expandXIncludesOnLoad = $("#expand-xincludes-on-load").is(":checked");
 			var doc = editor.getActiveDocument();
 			if (doc.getPath().match("^__new__") || !doc.isSaved()) {
 				util.error("There are unsaved changes in the document. Please save it first.");
 				return;
 			}
-			window.location.href = "modules/load.xql?download=true&path=" + encodeURIComponent(doc.getPath());
+			window.location.href = "modules/load.xql?download=true&path=" + encodeURIComponent(doc.getPath()) + "&indent=" + indentOnLoad + "&expand-xincludes=" + expandXIncludesOnLoad;
 		},
         
 		runQuery: function(path, livePreview) {

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -33,6 +33,8 @@ eXide.util.Preferences = (function () {
 		showHScroll: false,
         indent: -1,
         indentSize: 4,
+        indentOnLoad: true,
+        expandXIncludesOnLoad: false,
         softWrap: -1,
         emmet: false
 	};
@@ -74,6 +76,8 @@ eXide.util.Preferences = (function () {
         $("select[name=\"theme\"]", form).val(this.preferences.theme);
 		$("select[name=\"font-size\"]", form).val(this.preferences.fontSize);
         $("select[name=\"font\"]", form).val(this.preferences.font);
+		$("input[name=\"indent-on-load\"]", form).attr("checked", this.preferences.indentOnLoad);
+		$("input[name=\"expand-xincludes-on-load\"]", form).attr("checked", this.preferences.expandXIncludesOnLoad);
 		$("input[name=\"show-invisibles\"]", form).attr("checked", this.preferences.showInvisibles);
 		$("input[name=\"print-margin\"]", form).attr("checked", this.preferences.showPrintMargin);
 		$("input[name=\"emmet\"]", form).attr("checked", this.preferences.emmet);
@@ -102,6 +106,8 @@ eXide.util.Preferences = (function () {
         this.preferences.theme = $("select[name=\"theme\"]", form).val();
 		this.preferences.fontSize = parseInt($("select[name=\"font-size\"]", form).val());
         this.preferences.font = $("select[name=\"font\"]", form).val();
+        this.preferences.indentOnLoad = $("select[name=\"indent-on-load\"]", form).val().is(":checked");
+        this.preferences.expandXIncludesOnLoad = $("select[name=\"expand-xincludes-on-load\"]", form).val().is(":checked");
 		this.preferences.showInvisibles = $("input[name=\"show-invisibles\"]", form).is(":checked");
 		this.preferences.showPrintMargin = $("input[name=\"print-margin\"]", form).is(":checked");
 		this.preferences.emmet = $("input[name=\"emmet\"]", form).is(":checked");


### PR DESCRIPTION
Before this PR eXide hard-coded serialization parameters—`indent=yes expand-xincludes=no` when opening and downloading XML documents from the database and `indent=no expand-xincludes=no` when generating and downloading packages—and users had no means to change this behavior. Numerous times the indentation behavior of eXide caused confusion when users opened documents or saved documents and observed whitespace introduced into their documents. See these posts to exist-open:

- [eXide expands XIncludes when opening XML files (2012)](https://markmail.org/message/slp5yzin6tj6y6pa) 
- [How to prevent indenting with eXide / eXist ? (2017)](https://markmail.org/message/f2fallfhh7sb6hu7)
- [how can indentation of element-only nodes be suppressed? (2020)](https://markmail.org/message/tzy6rknvqu5rpsbg) 

The only solution was to [suggest editing eXide's sources to change the hardcoded default](https://markmail.org/message/tzy6rknvqu5rpsbg) or to use a different editor.

This PR adds preferences for these two serialization parameters to the eXide preferences window:

> <img width="608" alt="Screen Shot 2021-07-07 at 5 47 00 PM" src="https://user-images.githubusercontent.com/59118/124832907-582fc900-df4b-11eb-9095-7f39742919a2.png">

The preferences default to the longstanding eXide defaults for opening and downloading individual documents: `indent=yes expand-xincludes=no`. The preferences also now govern serialization when generating and downloading packages via Application > Download app, and thus the default here is changed from a hardcoded `indent=no` to follow the eXide Preference. 

The `load.xql` endpoint now supports `indent` and `expand-xincludes` parameters, just as `deployment.xql` had already done.

Alternatives I considered:

- Showing these preferences in the editor window. I opted to place these options in Preferences since in the main editor window, they would take up valuable space; there's no good place for this in the UI; the "indent on load" checkbox could cause confusion with the "indent" checkbox in the results pane; and we've never had the ability to adjust this before, so it's doubtful we'd want/need to toggle this all of the time. Let's give this a try and see if we really need to toggle this on .
- Providing distinct preferences for (a) opening/downloading individual documents vs. (b) generating & downloading packages. I opted for a single set of preferences for simplicity's sake; it seems to me that if you like indentation, you'd want it everywhere, but if you don't want indentation, you'll disable it and want to keep it off.
- Setting the defaults via eXide's `configuration.xml` file instead of `src/preferences.js` - but none of the other preferences are set there, and I am not capable of the javascript needed to get the `preferences.js` file to read eXide's prefs from the `configuration.xml` file.

Previous work in this area includes: 

- https://github.com/eXist-db/eXide/pull/158
- https://github.com/eXist-db/eXide/pull/272