### PR TITLE
Fix "outline" and "directory" sidebar layout, issue #317

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ node_modules/
 
 cypress/videos/*.mp4
 cypress/screenshots/**/*.png
+
+.*
+!.gitignore
+!.existdb.json
+!.gitmodules

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -344,19 +344,15 @@
 
                             <div id="outline-body">
                                 <div class="ace_scroller">
-                                    <div class="ace_text-layer">
-                                        <ul id="outline"/>
-                                    </div>
+                                    <ul id="outline"/>
                                 </div>
                             </div>
                             <div id="directory-body">
                                 <div class="ace_scroller">
-                                    <div class="ace_text-layer">
-                                        <div class="tree">
-                                            <ul id="directory">
-                                                <li id="tree-root"/>
-                                            </ul>
-                                        </div>
+                                    <div class="tree">
+                                        <ul id="directory">
+                                            <li id="tree-root"/>
+                                        </ul>
                                     </div>
                                 </div>
                             </div>

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -1057,35 +1057,30 @@ Sub level menu list items (undo style from Top level List Items)
 
 #outline {
     font-family: 'Ubuntu Mono', 'Monaco', 'Menlo', 'Droid Sans Mono', 'Courier New', monospace;
-    line-height: 0.9em;
+    line-height: 1.3em;
     list-style: none;
     margin: 8px 4px 16px 4px;
     padding: 0;
-    height: 100%;
     white-space: pre-wrap;
-    /*  Added by CG  */
-    font-size: 75%;
-    /*  End Added */
+    font-size: .7em;
 }
 
-#outline li {
-    /*  Added by CG  */
-    margin: 0px 0px 2px 0px;
-    /*  End Added */
-}
-
-#outline .private, #outline .public {
-    background-repeat: no-repeat;
-    background-position: left;
-    padding-left: 15px;
+#outline .public {
+    background-image: url(../images/public.png);
 }
 
 #outline .private {
     background-image: url(../images/private.png);
 }
 
-#outline .public {
-    background-image: url(../images/public.png);
+#outline li {
+    margin: 0 0 2px 0;
+    padding: 0 0 0 18px;
+    text-align: left;
+    background-size: 4%;
+    background-position-x: 0%;
+    background-position-y: 100%;
+    background-repeat: no-repeat;
 }
 
 #outline a:link, #outline a:visited {

--- a/src/outline.js
+++ b/src/outline.js
@@ -140,6 +140,10 @@ eXide.edit.Outline = (function () {
                             ? "ace_support.ace_function"
                             : "ace_variable";
                     })
+                    .attr("class",function(d) {
+                      var cl =  d.type == eXide.edit.Document.TYPE_FUNCTION ?  "t.function" : "t_variable";
+                      return cl + " " + (d.visibility === "private" ? "private" : "public" );
+                    })
                     .append("a")
                         .style("opacity", 0)
                         .attr("title", function(d) {
@@ -148,10 +152,6 @@ eXide.edit.Outline = (function () {
                         })
                         .attr("href", function(d) {
                             return  "#" + (d.source ? d.source : "");
-                        })
-                        .attr("class",function(d) {
-                            var cl =  d.type == eXide.edit.Document.TYPE_FUNCTION ?  "t.function" : "t_variable";
-                            return cl + " " + (d.visibility === "private" ? "private" : "public" );
                         })
                        .text(function(d) {
                             if (d.type == eXide.edit.Document.TYPE_VARIABLE) {


### PR DESCRIPTION
1. Reinstate sidebar scrolling, enhance "outline" tab #317 
* Move background image from nested anchor element to its parent
list-item in order to control the left alignment of text inside the
anchor. As a result, long lines will align correctly inside the anchor
and not float  under the background-image
* Improve legibility and targeting (e.g. mouse-click): Increase
line-height, space and position the background image next to the first
line of each list-item.

2. General:
* Enable scrolling and reinstate correct height and width of sidebars.
* Delete obsolete comments & code

3. Remove wrapping containers of sidebar containers "outline" and
"directory".

4. Exclude IDE files from revision

<img width="355" alt="Screenshot 2021-08-25 at 17 48 46" src="https://user-images.githubusercontent.com/1157669/130827475-effa501c-1d0b-4e31-9125-8c89790306ee.png">

<img width="315" alt="Screenshot 2021-08-25 at 17 49 42" src="https://user-images.githubusercontent.com/1157669/130827510-1e90b91c-6b71-48b7-a70c-564620d9d368.png">
