### PR TITLE
Revert "[feature] Add prefs for indent, xinclude on load"

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -581,7 +581,6 @@
                 <div id="preferences-dialog">
                     <form>
                         <fieldset>
-                            <legend>Editor</legend>
                             <ol>
                                 <li>
                                     <select id="theme" name="theme">
@@ -663,7 +662,7 @@
                                         <option value="4">4 spaces</option>
                                         <option value="8">8 spaces</option>
                                     </select>
-                                    <label for="indent-size">Indent size:</label>
+                                    <label for="indent-size">indent size:</label>
                                 </li>
                                 <li>
                                     <select name="soft-wrap">
@@ -681,19 +680,6 @@
                                 <li>
                                     <input type="checkbox" name="emmet"/>
                                     <label for="emmet">Enable emmet in HTML mode:</label>
-                                </li>
-                            </ol>
-                        </fieldset>
-                        <fieldset>
-                            <legend>When opening or downloading XML documents</legend>
-                            <ol>
-                                <li>
-                                    <input type="checkbox" name="indent-on-load" id="indent-on-load"/>
-                                    <label for="indent-on-load">Indent:</label>
-                                </li>
-                                <li>
-                                    <input type="checkbox" name="expand-xincludes-on-load" id="expand-xincludes-on-load"/>
-                                    <label for="expand-xincludes-on-load">Expand XIncludes:</label>
                                 </li>
                             </ol>
                         </fieldset>

--- a/modules/deployment.xql
+++ b/modules/deployment.xql
@@ -641,8 +641,8 @@ let $collection :=
         repo:get-root() || $target
 let $info := request:get-parameter("info", ())
 let $download := request:get-parameter("download", ())
-let $expand-xincludes := request:get-parameter("expand-xincludes", ()) cast as xs:boolean
-let $indent := request:get-parameter("indent", ()) cast as xs:boolean
+let $expand-xincludes := request:get-parameter("expand-xincludes", "false") cast as xs:boolean
+let $indent := request:get-parameter("indent", "false") cast as xs:boolean
 let $expathConf := if ($collection) then xmldb:xcollection($collection)/expath:package else ()
 let $repoConf := if ($collection) then xmldb:xcollection($collection)/repo:meta else ()
 let $abbrev := request:get-parameter("abbrev", ())

--- a/src/deployment.js
+++ b/src/deployment.js
@@ -212,9 +212,7 @@ eXide.edit.PackageEditor = (function () {
     eXide.util.oop.inherit(Constr, eXide.events.Sender);
 
     Constr.prototype.download = function (collection) {
-        var indentOnLoad = $("#indent-on-load").is(":checked");
-        var expandXIncludesOnLoad = $("#expand-xincludes-on-load").is(":checked");
-		window.location.href = "modules/deployment.xql?download=true&collection=" + encodeURIComponent(collection) + "&indent=" + indentOnLoad + "&expand-xincludes=" + expandXIncludesOnLoad;
+        window.location.href = "modules/deployment.xql?download=true&collection=" + encodeURIComponent(collection);
     };
     
 	/**

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -291,8 +291,6 @@ eXide.app = (function(util) {
 
 		$doOpenDocument: function(resource, callback, reload) {
 			resource.path = util.normalizePath(resource.path);
-            var indentOnLoad = $("#indent-on-load").is(":checked");
-            var expandXIncludesOnLoad = $("#expand-xincludes-on-load").is(":checked");
             var doc = editor.getDocument(resource.path);
             if (doc && !reload) {
                 editor.switchTo(doc);
@@ -302,9 +300,8 @@ eXide.app = (function(util) {
                 return true;
             }
 			$.ajax({
-				url: "modules/load.xql",
+				url: "modules/load.xql?path=" + resource.path,
 				dataType: 'text',
-				data: { "path": resource.path, "indent": indentOnLoad, "expand-xincludes": expandXIncludesOnLoad },
 				success: function (data, status, xhr) {
                     if (reload) {
                         editor.reload(data);
@@ -449,14 +446,12 @@ eXide.app = (function(util) {
         },
         
 		download: function() {
-            var indentOnLoad = $("#indent-on-load").is(":checked");
-            var expandXIncludesOnLoad = $("#expand-xincludes-on-load").is(":checked");
 			var doc = editor.getActiveDocument();
 			if (doc.getPath().match("^__new__") || !doc.isSaved()) {
 				util.error("There are unsaved changes in the document. Please save it first.");
 				return;
 			}
-			window.location.href = "modules/load.xql?download=true&path=" + encodeURIComponent(doc.getPath()) + "&indent=" + indentOnLoad + "&expand-xincludes=" + expandXIncludesOnLoad;
+			window.location.href = "modules/load.xql?download=true&path=" + encodeURIComponent(doc.getPath());
 		},
         
 		runQuery: function(path, livePreview) {

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -33,8 +33,6 @@ eXide.util.Preferences = (function () {
 		showHScroll: false,
         indent: -1,
         indentSize: 4,
-        indentOnLoad: true,
-        expandXIncludesOnLoad: false,
         softWrap: -1,
         emmet: false
 	};
@@ -76,8 +74,6 @@ eXide.util.Preferences = (function () {
         $("select[name=\"theme\"]", form).val(this.preferences.theme);
 		$("select[name=\"font-size\"]", form).val(this.preferences.fontSize);
         $("select[name=\"font\"]", form).val(this.preferences.font);
-		$("input[name=\"indent-on-load\"]", form).attr("checked", this.preferences.indentOnLoad);
-		$("input[name=\"expand-xincludes-on-load\"]", form).attr("checked", this.preferences.expandXIncludesOnLoad);
 		$("input[name=\"show-invisibles\"]", form).attr("checked", this.preferences.showInvisibles);
 		$("input[name=\"print-margin\"]", form).attr("checked", this.preferences.showPrintMargin);
 		$("input[name=\"emmet\"]", form).attr("checked", this.preferences.emmet);
@@ -106,8 +102,6 @@ eXide.util.Preferences = (function () {
         this.preferences.theme = $("select[name=\"theme\"]", form).val();
 		this.preferences.fontSize = parseInt($("select[name=\"font-size\"]", form).val());
         this.preferences.font = $("select[name=\"font\"]", form).val();
-        this.preferences.indentOnLoad = $("select[name=\"indent-on-load\"]", form).val().is(":checked");
-        this.preferences.expandXIncludesOnLoad = $("select[name=\"expand-xincludes-on-load\"]", form).val().is(":checked");
 		this.preferences.showInvisibles = $("input[name=\"show-invisibles\"]", form).is(":checked");
 		this.preferences.showPrintMargin = $("input[name=\"print-margin\"]", form).is(":checked");
 		this.preferences.emmet = $("input[name=\"emmet\"]", form).is(":checked");


### PR DESCRIPTION
This reverts commit 1bc05d10c5ca198c1853ec738d62a4f75de17bbd (part of https://github.com/eXist-db/eXide/pull/328), so that new versions of eXide can be released incorporating other improvements. At the moment, the problems with this commit, described in https://github.com/eXist-db/eXide/issues/334 (with an attempted fix in https://github.com/eXist-db/eXide/pull/335, pending help from @wolfgangmm), are holding up release of other important fixes. 

Once this PR is merged, I'll prepare a new patch release of eXide (3.1.1), which will incorporate recent PRs like https://github.com/eXist-db/eXide/pull/353, https://github.com/eXist-db/eXide/pull/358, and https://github.com/eXist-db/eXide/pull/371.