### PR TITLE
Include ag-grid in build (see eXist-db/eXide#376)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ resources/scripts/xqlint.min.js
 resources/scripts/ace
 resources/scripts/eXide.min.*
 resources/scripts/jquery/jquery.plugins.min.*
+resources/css/ag-grid-community/
 
 tools/r.js
 

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -6,8 +6,8 @@
         <link rel="stylesheet" type="text/css" href="resources/css/black-tie/jquery-ui-1.10.3.custom.min.css"/>
         <link rel="stylesheet" type="text/css" href="resources/css/jquery.pnotify.default.css"/>
         <link rel="stylesheet" href="resources/css/font-awesome/css/font-awesome.min.css"/>
-        <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css"/>
-        <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-theme-alpine.css"/>
+        <link rel="stylesheet" href="resources/css/ag-grid-community/ag-grid.css"/>
+        <link rel="stylesheet" href="resources/css/ag-grid-community/ag-theme-alpine.css"/>
         <link rel="stylesheet" type="text/css" href="resources/css/eXide.css"/>
         <script type="text/javascript" src="resources/scripts/modernizr.custom.js"/>
         <script type="text/javascript" src="resources/scripts/jquery/jquery-1.9.1.min.js"/>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -125,6 +125,7 @@ async function clean() {
         'resources/scripts/jquery/jquery.plugins.min.js', 
         'resources/scripts/xqlint.min.js', 
         'resources/scripts/ace/**',
+        'resources/css/ag-grid-community/**',
         'index.html',
         'expath-pkg.xml'
     ], { allowEmpty: true, silent: false });
@@ -180,6 +181,8 @@ function replace(path, outPath, data) {
     }
 
     await mfs.copy('./support/ace/build/src-min/**', './resources/scripts/ace');
+    await mfs.copy('./node_modules/@ag-grid-community/core/LICENSE.txt', './resources/css/ag-grid-community');
+    await mfs.copy('./node_modules/@ag-grid-community/core/dist/styles/*.css', './resources/css/ag-grid-community');
     
     replace('expath-pkg.xml.tmpl', 'expath-pkg.xml', { version });
     replace("index.html.tmpl", "index.html", { version });


### PR DESCRIPTION
The build process copies CSS within `node_modules/@ag-grid-community` into a git-ignored directory `resources/css/ag-grid-community`. The eXide HTML template now references local copies of the ag-grid CSS, thus bypassing CORS issues and allowing the Open / Manage dialogs to work offline.

Tested locally using eXist v5.3.1 on a Mac.