### PR TITLE
Fix snippets for XQuery 3.1

### DIFF
--- a/templates/xquery.snippets
+++ b/templates/xquery.snippets
@@ -65,7 +65,8 @@ snippet json
 	declare option output:media-type "application/json";
 	
 snippet html5
-	declare option output:method "html5";
+	declare option output:method "html";
+	declare option output:html-version "5.0";
 	declare option output:media-type "text/html";
 
 snippet html
@@ -107,7 +108,7 @@ snippet case
 	case element(${1:name}) return
 
 snippet xq
-	xquery version="3.0";
+	xquery version "3.1";
 	
 snippet tei
 	declare namespace tei="http://www.tei-c.org/ns/1.0";


### PR DESCRIPTION
The snippet with the XQuery version declaration contained a syntax error. 

The snippet with the HTML5 serialization is updated to conform to the XSLT and XQuery Serialization 3.1 spec, at https://www.w3.org/TR/xslt-xquery-serialization-31/#HTML_VERSION. While eXist is forgiving about `output:method="html5"`, this formulation will throw an error in Saxon and BaseX. 