### PR TITLE
Ensure errors in module inspection don’t halt docs

### DIFF
--- a/modules/docs.xql
+++ b/modules/docs.xql
@@ -52,7 +52,7 @@ declare function local:get-matching-functions($q as xs:string) {
         if ($supplied-module-namespace-prefix eq 'fn') then
             inspect:inspect-module-uri(xs:anyURI('http://www.w3.org/2005/xpath-functions'))
         else
-            let $all-modules := (util:registered-modules(), util:mapped-modules()) ! inspect:inspect-module-uri(xs:anyURI(.))
+            let $all-modules := (util:registered-modules(), util:mapped-modules()) ! (try { inspect:inspect-module-uri(xs:anyURI(.)) } catch * { () })
             return
                 if ($supplied-module-namespace-prefix) then
                     $all-modules[starts-with(@prefix, $supplied-module-namespace-prefix)]


### PR DESCRIPTION
In certain cases, an installed module is incompatible with eXist. For example, the current release of the EXPath Crypto module is [incompatible](https://github.com/eXist-db/expath-crypto-module/issues/64) with the current release of eXist. In this situation, passing this module’s URI to inspect:inspect-module-uri will throw an error. Without wrapping this call in a try-catch block, this error will cause requests to eXide’s docs.xql endpoint to return a server error. Wrapping them in a try-catch block allows the call to docs.xql to complete. Documentation for the failing module (crypto, in this scenario) won’t be available, obviously, but documentation for all other modules will be available.