### PR TITLE
Warn user when saving contents of XQuery window with non-.xq* file extension

### DIFF
--- a/src/eXide.js
+++ b/src/eXide.js
@@ -398,7 +398,7 @@ eXide.app = (function(util) {
     					"Save": function() {
                             // force saving XQuery files
                             if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
-                                util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery file, but you are trying to save it with a non-XQuery file extension (.xq, .xqm etc).  If you intended this to be another file type such as XML, copy and past the content into a New file created using the \"New\" button.");
+                                util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery file, but you are trying to save it with a non-XQuery file extension (.xq, .xqm etc).  If you intended this to be another file type such as XML, copy and paste the content into a New file created using the “New” button.");
                                 return;
                             }
                             
@@ -438,7 +438,7 @@ eXide.app = (function(util) {
     				"Save": function() {
                          // force saving XQuery files
                          if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
-                            util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery file, but you are trying to save it with a non-XQuery file extension (.xq, .xqm etc).  If you intended this to be another file type such as XML, copy and past the content into a New file created using the \"New\" button.");
+                            util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery file, but you are trying to save it with a non-XQuery file extension (.xq, .xqm etc).  If you intended this to be another file type such as XML, copy and paste the content into a New file created using the “New” button.");
                             return;
                         }
                         

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -398,7 +398,7 @@ eXide.app = (function(util) {
     					"Save": function() {
                             // force saving XQuery files
                             if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
-                                util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery, but you are trying to save it with a non XQuery File Extension  (e.g. not .xq). If you intended this to be an XML file, or an other file type, then please copy and paste the content of your file into a New file that you create using the “New” button.");
+                                util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery file, but you are trying to save it with a non-XQuery file extension (.xq, .xqm etc).  If you intended this to be another file type such as XML, copy and past the content into a New file created using the \"New\" button.");
                                 return;
                             }
                             
@@ -438,7 +438,7 @@ eXide.app = (function(util) {
     				"Save": function() {
                          // force saving XQuery files
                          if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
-                            util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery, but you are trying to save it with a non XQuery File Extension  (e.g. not .xq). If you intended this to be an XML file, or an other file type, then please copy and paste the content of your file into a New file that you create using the “New” button.");
+                            util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery file, but you are trying to save it with a non-XQuery file extension (.xq, .xqm etc).  If you intended this to be another file type such as XML, copy and past the content into a New file created using the \"New\" button.");
                             return;
                         }
                         

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -397,8 +397,8 @@ eXide.app = (function(util) {
         				},
     					"Save": function() {
                             // force saving XQuery files
-                            if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq*/.test(dbBrowser.getSelection().name)) {
-                                util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format");
+                            if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
+                                util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format ,if you are working on xml file consider copying and pasting the file into a new window using the `New` button instead of the `New XQuery`");
                                 return;
                             }
                             
@@ -437,8 +437,8 @@ eXide.app = (function(util) {
     				},
     				"Save": function() {
                          // force saving XQuery files
-                         if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq*/.test(dbBrowser.getSelection().name)) {
-                            util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format");
+                         if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
+                            util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format ,if you are working on xml file consider copying and pasting the file into a new window using the `New` button instead of the `New XQuery`");
                             return;
                         }
                         

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -396,6 +396,12 @@ eXide.app = (function(util) {
                             $(this).dialog("close");
         				},
     					"Save": function() {
+                            // force saving XQuery files
+                            if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq*/.test(dbBrowser.getSelection().name)) {
+                                util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq*");
+                                return;
+                            }
+                            
     						editor.saveDocument(dbBrowser.getSelection(), function () {
     							$("#open-dialog").dialog("close");
                                 deploymentEditor.autoSync(editor.getActiveDocument().getBasePath());
@@ -430,6 +436,12 @@ eXide.app = (function(util) {
                         $(this).dialog("close");
     				},
     				"Save": function() {
+                         // force saving XQuery files
+                         if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq*/.test(dbBrowser.getSelection().name)) {
+                            util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq*");
+                            return;
+                        }
+                        
     					editor.saveDocument(dbBrowser.getSelection(), function () {
     						$("#open-dialog").dialog("close");
                             deploymentEditor.autoSync(editor.getActiveDocument().getBasePath());

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -398,7 +398,7 @@ eXide.app = (function(util) {
     					"Save": function() {
                             // force saving XQuery files
                             if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
-                                util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format ,if you are working on xml file consider copying and pasting the file into a new window using the `New` button instead of the `New XQuery`");
+                                util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery, but you are trying to save it with a non XQuery File Extension  (e.g. not .xq). If you intended this to be an XML file, or an other file type, then please copy and paste the content of your file into a New file that you create using the “New” button.");
                                 return;
                             }
                             
@@ -438,7 +438,7 @@ eXide.app = (function(util) {
     				"Save": function() {
                          // force saving XQuery files
                          if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq.?/.test(dbBrowser.getSelection().name)) {
-                            util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format ,if you are working on xml file consider copying and pasting the file into a new window using the `New` button instead of the `New XQuery`");
+                            util.Dialog.warning("Failed to Save Document", "Your current file is an XQuery, but you are trying to save it with a non XQuery File Extension  (e.g. not .xq). If you intended this to be an XML file, or an other file type, then please copy and paste the content of your file into a New file that you create using the “New” button.");
                             return;
                         }
                         

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -398,7 +398,7 @@ eXide.app = (function(util) {
     					"Save": function() {
                             // force saving XQuery files
                             if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq*/.test(dbBrowser.getSelection().name)) {
-                                util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq*");
+                                util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format");
                                 return;
                             }
                             
@@ -438,7 +438,7 @@ eXide.app = (function(util) {
     				"Save": function() {
                          // force saving XQuery files
                          if(editor.getActiveDocument().isXQuery() && !/([^\s\\])*\.xq*/.test(dbBrowser.getSelection().name)) {
-                            util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq*");
+                            util.Dialog.warning("Failed to Save Document", "you are saving XQuery file without .xq* format");
                             return;
                         }
                         


### PR DESCRIPTION
Fixes https://github.com/eXist-db/eXide/issues/126.

warns user when trying to save contents of XQuery window with non-.xq* file extension and prevents it
suggests to use a new file if content is non-xquery

![image](https://user-images.githubusercontent.com/30597211/166948844-39a222ff-6b13-478b-8b52-6f66b33d9033.png)

This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov.