### PR TITLE
Fix for login-dialog to focus into user box on load.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "exide",
-	"version": "3.3.1",
+	"version": "3.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "exide",
-			"version": "3.3.1",
+			"version": "3.4.0",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@ag-grid-community/core": "^26.2.1",

--- a/src/menu.js
+++ b/src/menu.js
@@ -113,6 +113,9 @@ eXide.util.Menubar = (function() {
             if ($this.editor) {
                 $this.editor.focus();
             }
+            if($('#login-dialog').is(':visible')) {
+                $("#login-dialog input:first").focus();
+            }
             $("ul li ul", $this.container).fadeOut(100);
             $("ul li>a", $this.container).removeClass("open");
         });


### PR DESCRIPTION
Closes https://github.com/eXist-db/eXide/issues/109.

Description: This Pull request is to fix the issue with the login Dialog so that it now focuses into the user box when the user is not logged in.

Desired behaviour: When someone is not logged in, and either clicks on `File > manage` and/or `File > save (and save-as)`, when the login-dialog form appears, it automatically focuses into the user text box rather than the editor still.  

This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/. 