### PR TITLE
Save as uses current file's collection closes #104

### DIFF
--- a/src/eXide.js
+++ b/src/eXide.js
@@ -389,6 +389,7 @@ eXide.app = (function(util) {
 		saveDocument: function() {
             app.requireLogin(function () {
                 if (editor.getActiveDocument().getPath().match('^__new__')) {
+                    dbBrowser.changeToCollection("/db");
         			dbBrowser.reload(["reload", "create"], "save");
     				$("#open-dialog").dialog("option", "title", "Save Document");
     				$("#open-dialog").dialog("option", "buttons", { 
@@ -428,7 +429,11 @@ eXide.app = (function(util) {
 
         saveDocumentAs: function() {
             app.requireLogin(function () {
-                dbBrowser.changeToCollection(editor.getActiveDocument().getBasePath());
+                if (editor.getActiveDocument().getPath().match('^__new__')) {
+                    dbBrowser.changeToCollection("/db");
+                }else {
+                    dbBrowser.changeToCollection(editor.getActiveDocument().getBasePath());
+                }
                 dbBrowser.reload(["reload", "create"], "save");
     			$("#open-dialog").dialog("option", "title", "Save Document As ...");
     			$("#open-dialog").dialog("option", "buttons", { 

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -428,6 +428,7 @@ eXide.app = (function(util) {
 
         saveDocumentAs: function() {
             app.requireLogin(function () {
+                dbBrowser.changeToCollection(editor.getActiveDocument().getBasePath());
                 dbBrowser.reload(["reload", "create"], "save");
     			$("#open-dialog").dialog("option", "title", "Save Document As ...");
     			$("#open-dialog").dialog("option", "buttons", { 


### PR DESCRIPTION
Fixes #104

 eXide's File > Save As dialog now uses current file collection as the collection.

This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.