### PR TITLE
modify comment logic and add more cases

### DIFF
--- a/src/ace-modes.js
+++ b/src/ace-modes.js
@@ -197,7 +197,7 @@ define("eXide/mode/behaviour/xquery", function(require, exports, module) {
                 }
             }
             if (text == ":") {
-                if (line.slice(cursor.column -1 ,cursor.column)) {
+                if (line.slice(cursor.column -1 ,cursor.column) === '(') {
                     return {
                         text: ":  :",
                         selection: [2, 2]

--- a/src/ace-modes.js
+++ b/src/ace-modes.js
@@ -194,6 +194,11 @@ define("eXide/mode/behaviour/xquery", function(require, exports, module) {
                         text: '\n' + " : ",
                         selection: [1, 3, 1, 3]
                     }
+                }else if (line.match(/^\s:/) && line.match(/.*:\)/) && cursor.column < line.length) {
+                    return {
+                      text: "\n : ",
+                      selection: [1, 3, 1, 3]
+                    };
                 }
             }
             if (text == ":") {

--- a/src/ace-modes.js
+++ b/src/ace-modes.js
@@ -176,9 +176,20 @@ define("eXide/mode/behaviour/xquery", function(require, exports, module) {
         this.add("comments", "insertion", function (state, action, editor, session, text) {
             var cursor = editor.getCursorPosition();
             var line = session.doc.getLine(cursor.row);
+            var nextLine = session.doc.getLine(cursor.row + 1);
             if (text == "\n") {
-                // if user presses return within a comment, insert ' : ' 
-                if (line.match(/^[\(\s]:/)) {
+                if(line.match(/^\(:.*:\)/) && cursor.column < line.length){
+                    return {
+                        text: '\n' + " : ",
+                        selection: [1, 3, 1, 3]
+                    }
+                }else if(line.match(/^\(:/) && !line.match(/.*:\)/)){
+                    return {
+                        text: '\n' + " : ",
+                        selection: [1, 3, 1, 3]
+                    }
+                    
+                }else if(line.match(/^\s:/) && (nextLine.match(/.*:\)/) || nextLine.match(/^\s:/))) {
                     return {
                         text: '\n' + " : ",
                         selection: [1, 3, 1, 3]
@@ -186,8 +197,7 @@ define("eXide/mode/behaviour/xquery", function(require, exports, module) {
                 }
             }
             if (text == ":") {
-                var leftChar = line.substring(cursor.column - 1, 1);
-                if (leftChar == "(") {
+                if (line.match(/^[\(\s]:/)) {
                     return {
                         text: ":  :",
                         selection: [2, 2]

--- a/src/ace-modes.js
+++ b/src/ace-modes.js
@@ -197,7 +197,7 @@ define("eXide/mode/behaviour/xquery", function(require, exports, module) {
                 }
             }
             if (text == ":") {
-                if (line.match(/^[\(\s]:/)) {
+                if (line.slice(cursor.column -1 ,cursor.column)) {
                     return {
                         text: ":  :",
                         selection: [2, 2]


### PR DESCRIPTION
fixes #112
After closing an XQuery comment, pressing return causes a newline with a space + colon:
```
(: this is a comment :)
 : 
```
We adjusted the logic that decides when a colon should spawn to prevent the case above.
And here are the cases of when a colon should spawn:
* the cursor is in between the comment brackets `(:  |  :)`
* the line start with a `(:` and there is no closing bracket 
* you are in the middle of a comment and the line starts with ` :` 


This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.