### PR TITLE
Add download button to DB Manager view 

### DIFF
--- a/src/deployment.js
+++ b/src/deployment.js
@@ -215,7 +215,19 @@ eXide.edit.PackageEditor = (function () {
         var indentOnDownloadPackage = $("#indent-on-download-package").is(":checked");
         var expandXIncludesOnDownloadPackage = $("#expand-xincludes-on-download-package").is(":checked");
         var omitXMLDeclatarionOnDownloadPackage = $("#omit-xml-decl-on-download-package").is(":checked");
-        window.location.href = "modules/deployment.xq?download=true&collection=" + encodeURIComponent(collection) + "&indent=" + indentOnDownloadPackage + "&expand-xincludes=" + expandXIncludesOnDownloadPackage + "&omit-xml-decl=" + omitXMLDeclatarionOnDownloadPackage;
+        const url = "modules/deployment.xq?download=true&collection=" + encodeURIComponent(collection) + "&indent=" + indentOnDownloadPackage + "&expand-xincludes=" + expandXIncludesOnDownloadPackage + "&omit-xml-decl=" + omitXMLDeclatarionOnDownloadPackage;
+        fetch(url)
+            .then(resp => resp.blob())
+            .then(blob => {
+                const url = window.URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.style.display = 'none';
+                a.href = url;
+                a.download = decodeURI(collection.split("/").slice(-1)[0]);
+                document.body.appendChild(a);
+                a.click();
+                window.URL.revokeObjectURL(url);
+            })
     };
     
 	/**

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -289,7 +289,7 @@ eXide.app = (function(util) {
 				$("#open-dialog").dialog("close");
 		},
 
-        saveSelectedDocument: function(doc, close) {
+        downloadSelectedDocument: function(doc, close) {
 			var resource = doc || dbBrowser.getSelection();
 			if (resource) {
 				app.download(resource.path);

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -480,7 +480,7 @@ eXide.app = (function(util) {
 				return;
 			}
             var path = path || doc.getPath()
-            window.location.href = "modules/load.xql?download=true&path=" + encodeURIComponent(path) + "&indent=" + indentOnDownload + "&expand-xincludes=" + expandXIncludesOnDownload + "&omit-xml-decl=" + omitXMLDeclatarionOnDownload;
+            window.location.href = "modules/load.xq?download=true&path=" + encodeURIComponent(path) + "&indent=" + indentOnDownload + "&expand-xincludes=" + expandXIncludesOnDownload + "&omit-xml-decl=" + omitXMLDeclatarionOnDownload;
 		},
         
 		runQuery: function(path, livePreview) {

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -292,14 +292,14 @@ eXide.app = (function(util) {
         downloadSelectedDocument: function(docs, close) {
 			var resources = docs;
 			if (resources) {
-                let collectionsExist = resources.filter(res => res.isCollection).length > 0;
-                if(!collectionsExist) {
-                    resources.forEach(resource => {
-                        app.download(resource.key);
-                    })
-                }else {
-                    util.Dialog.warning("Invalid selection","The Download Selected command requires that only resources be selected (not collections). Please select a resources for download.")
-                }
+                resources.filter(res => res.isCollection).forEach(collection => {
+                    deploymentEditor.download(collection.key);
+                });
+
+                resources.filter(res => !res.isCollection).forEach(resource => {
+                    app.download(resource.key);
+                })
+
 			}else {
                 util.Dialog.warning("Invalid selection","The Download Selected command requires that resources be selected. Please select a resources for download.")
             }

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -289,6 +289,15 @@ eXide.app = (function(util) {
 				$("#open-dialog").dialog("close");
 		},
 
+        saveSelectedDocument: function(doc, close) {
+			var resource = doc || dbBrowser.getSelection();
+			if (resource) {
+				app.download(resource.path);
+			}
+			if (close == undefined || close)
+				$("#open-dialog").dialog("close");
+		},
+
 		$doOpenDocument: function(resource, callback, reload) {
 			resource.path = util.normalizePath(resource.path);
             var indentOnOpen = $("#indent-on-open").is(":checked");
@@ -461,16 +470,17 @@ eXide.app = (function(util) {
             editor.exec(arguments);
         },
         
-		download: function() {
+        download: function(path) {
             var indentOnDownload = $("#indent-on-download").is(":checked");
             var expandXIncludesOnDownload = $("#expand-xincludes-on-download").is(":checked");
             var omitXMLDeclatarionOnDownload = $("#omit-xml-decl-on-download").is(":checked");
 			var doc = editor.getActiveDocument();
-			if (doc.getPath().match("^__new__") || !doc.isSaved()) {
+			if (!path && (doc.getPath().match("^__new__") || !doc.isSaved())) {
 				util.error("There are unsaved changes in the document. Please save it first.");
 				return;
 			}
-            window.location.href = "modules/load.xq?download=true&path=" + encodeURIComponent(doc.getPath()) + "&indent=" + indentOnDownload + "&expand-xincludes=" + expandXIncludesOnDownload + "&omit-xml-decl=" + omitXMLDeclatarionOnDownload;
+            var path = path || doc.getPath()
+            window.location.href = "modules/load.xql?download=true&path=" + encodeURIComponent(path) + "&indent=" + indentOnDownload + "&expand-xincludes=" + expandXIncludesOnDownload + "&omit-xml-decl=" + omitXMLDeclatarionOnDownload;
 		},
         
 		runQuery: function(path, livePreview) {

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -655,7 +655,7 @@ eXide.app = (function(util) {
 		
 		manage: function() {
 			app.requireLogin(function() {
-                dbBrowser.reload(["reload", "create", "upload", "properties", "open", "cut", "copy", "paste"], "manage");
+                dbBrowser.reload(["reload", "create", "upload", "properties", "open", "download", "cut", "copy", "paste"], "manage");
                 $("#open-dialog").dialog("option", "title", "DB Manager");
                 $("#open-dialog").dialog("option", "buttons", { 
                     "Close": function() { $(this).dialog("close"); }

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -293,7 +293,9 @@ eXide.app = (function(util) {
 			var resource = doc || dbBrowser.getSelection();
 			if (resource) {
 				app.download(resource.path);
-			}
+			}else {
+                util.Dialog.warning("Error in selection","eXide didn't recognize your selection please select a single resource first. current state doesn't support selecting collections or multiple resources")
+            }
 			if (close == undefined || close)
 				$("#open-dialog").dialog("close");
 		},

--- a/src/resources.js
+++ b/src/resources.js
@@ -782,6 +782,12 @@ eXide.browse.Browser = (function () {
 			eXide.app.openSelectedDocument(null, false);
 		});
 
+		button = createButton(toolbar, "Download Selected", "download", 11, "download");
+		$(button).click(function (ev) {
+			ev.preventDefault();
+			alert("download")
+		});
+
         this.btnCopy = createButton(toolbar, "Copy", "copy", 7, "copy");
         this.btnCut = createButton(toolbar, "Cut", "cut", 8, "cut");
         this.btnPaste = createButton(toolbar, "Paste", "paste", 9, "paste");

--- a/src/resources.js
+++ b/src/resources.js
@@ -785,7 +785,7 @@ eXide.browse.Browser = (function () {
 		button = createButton(toolbar, "Download Selected", "download", 11, "download");
 		$(button).click(function (ev) {
 			ev.preventDefault();
-			alert("download")
+			eXide.app.saveSelectedDocument(null, false);
 		});
 
         this.btnCopy = createButton(toolbar, "Copy", "copy", 7, "copy");

--- a/src/resources.js
+++ b/src/resources.js
@@ -785,7 +785,7 @@ eXide.browse.Browser = (function () {
 		button = createButton(toolbar, "Download Selected", "download", 11, "download");
 		$(button).click(function (ev) {
 			ev.preventDefault();
-			eXide.app.saveSelectedDocument(null, false);
+			eXide.app.downloadSelectedDocument(null, false);
 		});
 
         this.btnCopy = createButton(toolbar, "Copy", "copy", 7, "copy");

--- a/src/resources.js
+++ b/src/resources.js
@@ -419,12 +419,8 @@ eXide.browse.ResourceBrowser = (function () {
 		if (selected.length == 0) {
 			return null;
 		}
-        var items = [];
-        for (var i = 0; i < selected.length; i++) {
-            var item = this.dataSource.collection + "/" + selected[i].name;
-            items.push(item);
-        }
-        return items;
+        
+        return selected;
     };
 
 	Constr.prototype.startEditing = function() {
@@ -785,7 +781,8 @@ eXide.browse.Browser = (function () {
 		button = createButton(toolbar, "Download Selected", "download", 11, "download");
 		$(button).click(function (ev) {
 			ev.preventDefault();
-			eXide.app.downloadSelectedDocument(null, false);
+			const selected = $this.resources.getSelected();
+			eXide.app.downloadSelectedDocument(selected, false);
 		});
 
         this.btnCopy = createButton(toolbar, "Copy", "copy", 7, "copy");


### PR DESCRIPTION
fixes #111 
 DB Manager view (File > Manage) now has a Download button to download a selected resource.
 This only applies for files at the moment, you select the file then press Download in the toolbar.
 
 ![image](https://user-images.githubusercontent.com/30597211/174329174-25727ffc-a0dc-4f24-84df-1158a33c84be.png)

This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.