### PR TITLE
Re Enable login With configuration.xml set to guest=no

### DIFF
--- a/controller.xq
+++ b/controller.xq
@@ -64,8 +64,8 @@ declare function local:fallback-login($domain as xs:string, $maxAge as xs:dayTim
 declare function local:user-allowed() {
     (
         session:get-attribute("org.exist.login.user") and 
-        session:get-attribute("org.exist.login.user") != "guest" 
-        ) or config:get-configuration()/restrictions/@guest = "yes"
+        session:get-attribute("org.exist.login.user") ne "guest" 
+        ) or config:get-configuration()/restrictions/@guest eq "yes"
 };
 
 declare function local:query-execution-allowed() {

--- a/controller.xq
+++ b/controller.xq
@@ -63,9 +63,9 @@ declare function local:fallback-login($domain as xs:string, $maxAge as xs:dayTim
 
 declare function local:user-allowed() {
     (
-        request:get-attribute("org.exist.login.user") and
-        request:get-attribute("org.exist.login.user") != "guest"
-    ) or config:get-configuration()/restrictions/@guest = "yes"
+        session:get-attribute("org.exist.login.user") and 
+        session:get-attribute("org.exist.login.user") != "guest" 
+        ) or config:get-configuration()/restrictions/@guest = "yes"
 };
 
 declare function local:query-execution-allowed() {


### PR DESCRIPTION
Fixes #164 
The `local:user-allowed()` function now checks against `session` attributes instead of `request` attributes.
Implementing @rvdb fix stated here https://github.com/eXist-db/eXide/issues/164#issuecomment-342827531
This now re-enable login for guest user when configuration.xml set to guest=no 

This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.