### PR TITLE
Switch resource handling from name to key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
        matrix:
-         exist-version: [latest]
+         exist-version: [release ,latest]
          java-version: [8]
          node-version: ['14', '16']
     # TODO: see #563 could still be usefull for gulp builds 

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:8080/exist/apps",
-  "projectId": "6tyg6v"
+  "projectId": "6tyg6v",
+  "experimentalSessionAndOrigin": true
 }

--- a/cypress/integration/dbmanager.spec.js
+++ b/cypress/integration/dbmanager.spec.js
@@ -9,12 +9,15 @@ context("DB Manager", () => {
         cy.get("#ui-id-1").parents("div.ui-dialog ").within(() => {
           cy.get("div.ui-dialog-buttonset button").click()
         })
-        Cypress.Cookies.debug(true)
+        cy.wait(500)
         cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
         cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
         cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.wait(500)
         cy.get("#login-form input[name=user]").type("admin")
+        cy.wait(500)
         cy.get("#layout-container > div:nth-child(12) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+        cy.wait(500)
       })
     })
 
@@ -45,6 +48,7 @@ context("DB Manager", () => {
         cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type(collectionName)
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
   
         cy.get("div.eXide-browse-main").within(() => {
@@ -78,6 +82,7 @@ context("DB Manager", () => {
         // create collection to be renamed
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type("toBeRenamed")
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
 
         cy.get("div.eXide-browse-main").within(() => {
@@ -135,6 +140,7 @@ context("DB Manager", () => {
         // create collection to be renamed
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type("AéB")
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
 
         cy.get("div.eXide-browse-main").within(() => {
@@ -183,6 +189,7 @@ context("DB Manager", () => {
         // create collection to be renamed
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type("toBeCopiedAéB")
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
 
         cy.get("div.eXide-browse-main").within(() => {
@@ -199,6 +206,7 @@ context("DB Manager", () => {
         // create collection to be renamed
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type("toBeCopiedInAéB")
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
 
         cy.get("div.eXide-browse-main").within(() => {
@@ -277,6 +285,7 @@ context("DB Manager", () => {
         // create collection to be renamed
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type("toBeCopiedAéB")
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
 
         cy.get("div.eXide-browse-main").within(() => {
@@ -293,6 +302,7 @@ context("DB Manager", () => {
         // create collection to be renamed
         cy.get("#eXide-browse-toolbar-create").click()
         cy.get("#eXide-browse-collection-name").type("toBeCopiedInAéB")
+        cy.wait(500)
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
 
         cy.get("div.eXide-browse-main").within(() => {

--- a/cypress/integration/dbmanager.spec.js
+++ b/cypress/integration/dbmanager.spec.js
@@ -218,6 +218,7 @@ context("DB Manager", () => {
         cy.get("div.eXide-browse-main").within(() => {
           cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").click()
         })
+        cy.wait(500)
         //click on toolbar action
         cy.get("#eXide-browse-toolbar-copy").click()
 
@@ -241,14 +242,19 @@ context("DB Manager", () => {
         cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
         cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
         cy.get("div.eXide-browse-main").within(() => {
+          cy.wait(500)
           cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").click()
         })
+        cy.wait(500)
         cy.get("#eXide-browse-toolbar-delete-resource").click()
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+        cy.wait(500)
 
         cy.get("div.eXide-browse-main").within(() => {
+          cy.wait(500)
           cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").click()
         })
+        cy.wait(500)
 
         cy.get("#eXide-browse-toolbar-delete-resource").click()
         cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()

--- a/cypress/integration/dbmanager.spec.js
+++ b/cypress/integration/dbmanager.spec.js
@@ -1,0 +1,397 @@
+let collectionName = "abc"
+
+context("DB Manager", () => {
+  describe('DB Manager operations', () => {
+    beforeEach(() => {
+      cy.session('mySession', () => {
+        cy.visit(`/eXide/index.html`)
+        cy.wait(500)
+        cy.get("#ui-id-1").parents("div.ui-dialog ").within(() => {
+          cy.get("div.ui-dialog-buttonset button").click()
+        })
+        Cypress.Cookies.debug(true)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("#login-form input[name=user]").type("admin")
+        cy.get("#layout-container > div:nth-child(12) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+      })
+    })
+
+    it('should open the db manager', () => {
+      cy.visit(`/eXide/index.html`)
+      cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+      cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+      cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+      cy.get("#ui-id-11").should("be.visible")
+      cy.get("#ui-id-11").invoke("text").should("eq", "DB Manager")
+    })
+
+    it('should select the clicked document', () => {
+      cy.visit(`/eXide/index.html`)
+      cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+      cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+      cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+      cy.get("div.eXide-browse-main").within(() => {
+        cy.get("div[role=row][row-id=0]").find("div").first().click()
+        cy.get("div[role=row][row-id=0]").should("have.attr", "aria-selected", "true")
+      })
+    })
+    describe("collection creation",() => {
+      it("should create a new collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type(collectionName)
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+  
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", collectionName).should('exist');
+        })
+      })
+  
+      it("should delete the created collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", collectionName).click()
+        })
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", collectionName).should('not.exist')
+        })
+      })
+    })
+
+    describe("renaming operation", () => {
+      it("should create a new collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        // create collection to be renamed
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type("toBeRenamed")
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeRenamed").should('exist');
+        })
+      })
+
+      it("should rename selected", () => {
+        //open exide page
+        cy.visit(`/eXide/index.html`)
+        //click on warning
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        //open the db manager
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        //click on file by name
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeRenamed").click()
+        })
+        //click on toolbar action
+        cy.get("#eXide-browse-toolbar-rename").click()
+        cy.focused().type("AéB{enter}")
+        cy.wait(1000)
+
+        //check for modification
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").should('exist');
+        })
+      })
+
+      it("should delete the created collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").click()
+        })
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").should('not.exist')
+        })
+      })
+    })
+
+    describe("properties operation", () => {
+
+      it("should create a new collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        // create collection to be renamed
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type("AéB")
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").should('exist');
+        })
+      })
+
+      it("should check for properties", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").click()
+        })
+
+        cy.get("#eXide-browse-toolbar-properties").click()
+
+        cy.contains("Resource/collection properties").should("be.visible")
+      })
+
+      it("should delete the created collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").click()
+        })
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").should('not.exist')
+        })
+      })
+    })
+
+    describe("copy operation", () => {
+      it("should create collection to be copied",() => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        // create collection to be renamed
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type("toBeCopiedAéB")
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").should('exist');
+        })
+      })
+
+      it("should create collection to be copied in",() => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        // create collection to be renamed
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type("toBeCopiedInAéB")
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").should('exist');
+        })
+      })
+
+      it("should copy the collection",() => {
+        //open exide page
+        cy.visit(`/eXide/index.html`)
+        //click on warning
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        //open the db manager
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        //click on file by name
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").click()
+        })
+        //click on toolbar action
+        cy.get("#eXide-browse-toolbar-copy").click()
+
+        //navigate into collection
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").dblclick()
+        })
+
+        //paste the collection
+        cy.get("#eXide-browse-toolbar-paste").click()
+
+        //check for modification
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").should('exist');
+        })
+      })
+
+      it("should delete the created collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").click()
+        })
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").click()
+        })
+
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").should('not.exist')
+        })
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").should('not.exist')
+        })
+      })
+    })
+
+    describe("cut operation", () => {
+      it("should create collection to be copied",() => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        // create collection to be renamed
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type("toBeCopiedAéB")
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").should('exist');
+        })
+      })
+
+      it("should create collection to be copied in",() => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+
+        // create collection to be renamed
+        cy.get("#eXide-browse-toolbar-create").click()
+        cy.get("#eXide-browse-collection-name").type("toBeCopiedInAéB")
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").should('exist');
+        })
+      })
+
+      it("should cut the collection",() => {
+        //open exide page
+        cy.visit(`/eXide/index.html`)
+        //click on warning
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        //open the db manager
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        //click on file by name
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").click()
+        })
+        //click on toolbar action
+        cy.get("#eXide-browse-toolbar-cut").click()
+
+        //navigate into collection
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").dblclick()
+        })
+
+        //paste the collection
+        cy.get("#eXide-browse-toolbar-paste").click()
+
+        //check for modification
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").should('exist');
+        })
+      })
+
+      it("should delete the created collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").click()
+        })
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedInAéB").should('not.exist')
+        })
+        // check the collection is removed by cutting it
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "toBeCopiedAéB").should('not.exist')
+        })
+      })
+    })
+
+    describe("create resource", () => {
+      it("should create resource using xmldb",() => {
+        cy.request({
+          method: 'POST',
+          url: `/eXide/execute`,
+          form: true,
+          body: {
+            qu: `xquery version "3.1";
+
+            xmldb:create-collection("/db","AéB"),
+            xmldb:store(xmldb:encode("/db/AéB"), xmldb:encode("AéB.xml"), <foo/>)`,
+            base: 'xmldb:exist://__new__1',
+            output: 'adaptive'
+          }
+        })
+      })
+
+      it("should open resource",() => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").dblclick()
+          cy.contains("div[role=gridcell][col-id=name]", "AéB.xml").dblclick()
+        })
+
+        cy.contains("/db/AéB/AéB.xml").should('exist')
+        cy.contains("/db/AéB/AéB.xml").should('be.visible')
+
+        cy.get("#close").click()
+      })
+
+      it("should delete the created collection", () => {
+        cy.visit(`/eXide/index.html`)
+        cy.get("div.ui-dialog div.ui-dialog-buttonset button").filter(':visible').click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a").click()
+        cy.get("#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul").find("#menu-file-manager").click()
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").click()
+        })
+        cy.get("#eXide-browse-toolbar-delete-resource").click()
+        cy.get("body > div:nth-child(4) > div.ui-dialog-buttonpane.ui-widget-content.ui-helper-clearfix > div > button:nth-child(1)").click()
+
+        cy.get("div.eXide-browse-main").within(() => {
+          cy.contains("div[role=gridcell][col-id=name]", "AéB").should('not.exist')
+        })
+      })
+    })
+  })
+})

--- a/cypress/integration/exide_spec.js
+++ b/cypress/integration/exide_spec.js
@@ -8,6 +8,7 @@ describe('eXide', function() {
 
   })
   it('should display editor', function () {
+    cy.visit('/eXide/index.html')
     cy.get('.path')
     cy.contains('__new__1')
   })

--- a/src/directory.js
+++ b/src/directory.js
@@ -76,7 +76,7 @@ eXide.edit.Directory = (function () {
 			}
 			return fn(d)
 		}
-		d3.json("modules/collections.xq?root=" + (sel.datum().key || "/db") + "&view=r", function(error, data){
+		d3.json("modules/collections.xq?root=" + encodeURIComponent(sel.datum().key || "/db") + "&view=r", function(error, data){
 			if(error)	{
 				return
 			}

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -960,7 +960,7 @@ eXide.app = (function(util) {
         
         updateStatus: function(doc) {
             $("#syntax").val(doc.getSyntax());
-            $("#status .path").text(util.normalizePath(doc.getPath()));
+            $("#status .path").text(decodeURI(util.normalizePath(doc.getPath())));
             if (!doc.isNew() && (doc.getSyntax() == "xquery" || doc.getSyntax() == "html" || doc.getSyntax() == "xml")) {
                 $("#status a").attr("href", doc.getExternalLink());
                 $("#status a").css("visibility", "visible");

--- a/src/resources.js
+++ b/src/resources.js
@@ -305,13 +305,13 @@ eXide.browse.ResourceBrowser = (function () {
 			}
 		};
 		this.gridOptions.onCellValueChanged = (params) => {
-			if (!this.oldValue) {
+			if (!params.oldValue) {
 				return;
 			}
 			params.column.colDef.editable = false;
 			$.getJSON("modules/collections.xq", {
-				target: encodeURI(params.data.name),
-				rename: this.oldValue,
+				target: encodeURI(params.newValue),
+				rename: encodeURI(params.oldValue),
 				root: this.dataSource.collection
 			}, (data) => {
 				if (data.status == "fail") {

--- a/src/resources.js
+++ b/src/resources.js
@@ -340,7 +340,7 @@ eXide.browse.ResourceBrowser = (function () {
             		}
             		var resources = [];
             		for (var i = 0; i < selected.length; i++) {
-            			resources.push($this.dataSource.collection + "/" + selected[i].name);
+            			resources.push(selected[i].key);
             		}
                     var params = $("form", dialog).serialize();
                     params = params + "&" + $.param({ "modify[]": resources});
@@ -421,7 +421,7 @@ eXide.browse.ResourceBrowser = (function () {
 		}
         var items = [];
         for (var i = 0; i < selected.length; i++) {
-            var item = this.dataSource.collection + "/" + selected[i].name;
+            var item = selected[i].key;
             items.push(item);
         }
         return items;
@@ -524,7 +524,7 @@ eXide.browse.ResourceBrowser = (function () {
 		var resources = [];
 		for (var i = 0; i < selected.length; i++) {
             if (selected[i].name != "..") {
-			    resources.push(this.dataSource.collection + "/" + selected[i].name);
+			    resources.push(selected[i].key);
             }
 		}
         if (resources.length > 0) {
@@ -549,10 +549,8 @@ eXide.browse.ResourceBrowser = (function () {
 		}
         this.clipboard = [];
 		for (var i = 0; i < selected.length; i++) {
-            var path = selected[i].name;
-            if (path.substr(0, 1) != "/") {
-                path = this.dataSource.collection + "/" + path;
-            }
+            var path = selected[i].key;
+
 			this.clipboard.push(path);
 		}
         $.log("Clipboard: %o", this.clipboard);

--- a/src/resources.js
+++ b/src/resources.js
@@ -367,6 +367,7 @@ eXide.browse.ResourceBrowser = (function () {
         this.breadcrumbs.empty();
         var self = this;
         var parts = this.dataSource.collection.split("/");
+		parts = parts.map(part => decodeURI(part));
         var span = $("<span>/</span>");
         var path = "/";
         for (var i = 0; i < parts.length; i++) {

--- a/src/resources.js
+++ b/src/resources.js
@@ -166,13 +166,13 @@ eXide.browse.ResourceBrowser = (function () {
 				var coll;
 				if (params.data.name == "..")
 					coll = this.dataSource.collection.replace(/\/[^\/]+$/, "");
-				else coll = this.dataSource.collection + "/" + params.data.name;
+				else coll = params.data.key;
 				this.$triggerEvent("activateCollection", [coll, params.data.writable]);
 				this.update(coll, false);
 			} else {
 				eXide.app.openSelectedDocument({
 					name: params.data.name,
-					path: this.dataSource.collection + "/" + params.data.name,
+					path: params.data.key,
 					writable: params.data.writable
 				});
 			}
@@ -226,13 +226,13 @@ eXide.browse.ResourceBrowser = (function () {
 							if (e.data.name === "..")
 								coll = this.dataSource.collection.replace(/\/[^\/]+$/, "")
 							else
-								coll = this.dataSource.collection + "/" + e.data.name;
+								coll = e.data.key;
 							this.$triggerEvent("activateCollection", [ coll, e.data.writable ]);
 							this.update(coll, false);
 						} else {
 							eXide.app.openSelectedDocument({
 								name: e.data.name,
-								path: this.dataSource.collection + "/" + e.data.name,
+								path: e.data.key,
 								writable: e.data.writable,
 							});
 						}

--- a/src/resources.js
+++ b/src/resources.js
@@ -310,7 +310,7 @@ eXide.browse.ResourceBrowser = (function () {
 			}
 			params.column.colDef.editable = false;
 			$.getJSON("modules/collections.xq", {
-				target: params.data.name,
+				target: encodeURI(params.data.name),
 				rename: this.oldValue,
 				root: this.dataSource.collection
 			}, (data) => {
@@ -433,7 +433,7 @@ eXide.browse.ResourceBrowser = (function () {
 		if (cell.column.colId !== 'name') {
 			return;
 		}
-		this.oldValue = this.dataSource.data[cell.rowIndex].name;
+		this.oldValue = this.dataSource.data[cell.rowIndex].key;
 		cell.column.colDef.editable = true;
 		this.inEditor = true;
 		this.gridOptions.api.startEditingCell({


### PR DESCRIPTION
Fixes #185 
this PR switches to using key for resources in the DB manager for copying,renaming,navigation,creation 
now creating a collection named `AéB` or with spaces in the name will work fine
![image](https://user-images.githubusercontent.com/30597211/175096333-97962966-acd0-4848-9983-fd4fa32cf338.png)

This open source contribution to the [eXide](https://github.com/eXist-db/eXide) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.