### PR TITLE
Revert "display xqlint errors" PR

### DIFF
--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -163,10 +163,6 @@ eXide.edit.XQueryModeHelper = (function () {
 			},
 			contentType: "application/octet-stream",
 			success: function (data) {
-                if (data.result !== 'fail' && doc.error) {
-                    data.result = 'fail';
-                    data.error = doc.error;
-                }
 				var valid = $this.compileError(data, doc);
                 if (onComplete) {
 				    onComplete.call(this, valid);
@@ -210,7 +206,6 @@ eXide.edit.XQueryModeHelper = (function () {
             return;
         }
         $.log("Running xqlint...");
-        doc.error = false;
         var session = doc.getSession();
         var value = doc.getText();    
         var h = new JSONParseTreeHandler(value);
@@ -219,7 +214,6 @@ eXide.edit.XQueryModeHelper = (function () {
             parser.parse_XQuery();
         } catch(e) {
             $.log("Error while parsing XQuery: %s", parser.getErrorMessage(e));
-            doc.error = parser.getErrorMessage(e);
             if(e instanceof parser.ParseException) {
                 h.closeParseTree();
             }
@@ -261,7 +255,6 @@ eXide.edit.XQueryModeHelper = (function () {
             session.setAnnotations(annotations);
         } catch(e) {
             $.log("Error while processing ast: %s", e.message);
-            doc.error = doc.error || e.message;
         }
     };
     


### PR DESCRIPTION
This PR reverts commit fbbde083f82d30eefef7cbdac31e16ad2c2d54be, which was from PR https://github.com/eXist-db/eXide/pull/529. That PR allowed xqlint to report any errors to the user. While this is a laudable goal, it was only half of the fix needed to address the original issue that prompted it. The other half that is still needed is to update xqlint's XQuery 3.1 parser. Until eXide's xqlint is updated, eXide issues constant "lexical analysis failed" errors - making it virtually unusable.

Thus, I'd like to revert this PR. 

Of course, I also welcome @marmoure to resubmit the PR so that it can be considered when the xqlint issue is fixed. Thank you, Younes!
