### PR TITLE
Fix download of .xar packages

### DIFF
--- a/modules/deployment.xq
+++ b/modules/deployment.xq
@@ -585,12 +585,8 @@ declare function deploy:package($collection as xs:string, $expathConf as element
         xmldb:store("/db/system/repo", $name, $xar, "application/zip")
 };
 
-declare function deploy:download($collection as xs:string, $expathConf as element()?, $expand-xincludes as xs:boolean, $indent as xs:boolean, $omit-xml-declaration as xs:boolean) {
-    let $name := 
-        if ($expathConf) then
-            concat($expathConf/@abbrev, "-", $expathConf/@version, ".xar")
-        else
-            replace($collection, "^.+/([^/]+)$", "$1") || ".zip"
+declare function deploy:download($collection as xs:string, $expathConf as element(), $expand-xincludes as xs:boolean, $indent as xs:boolean, $omit-xml-declaration as xs:boolean) {
+    let $name := concat($expathConf/@abbrev, "-", $expathConf/@version, ".xar")
     let $entries :=
         (: compression:zip uses default serialization parameters, so we'll construct entries manually :)
         dbutil:scan(xs:anyURI($collection), function($coll as xs:anyURI, $res as xs:anyURI?) {
@@ -602,7 +598,6 @@ declare function deploy:download($collection as xs:string, $expathConf as elemen
                         <entry type="uri" name="{$relative-path}">{$res}</entry>
                     else
                         <entry type="xml" name="{$relative-path}">{
-                            (: workaround until https://github.com/eXist-db/exist/issues/2394 is resolved :)
                             util:declare-option(
                                 "exist:serialize", 
                                 "expand-xincludes=" 

--- a/src/deployment.js
+++ b/src/deployment.js
@@ -230,19 +230,7 @@ eXide.edit.PackageEditor = (function () {
         var indentOnDownloadPackage = $("#indent-on-download-package").is(":checked");
         var expandXIncludesOnDownloadPackage = $("#expand-xincludes-on-download-package").is(":checked");
         var omitXMLDeclatarionOnDownloadPackage = $("#omit-xml-declaration-on-download-package").is(":checked");
-        const url = "modules/deployment.xq?download=true&collection=" + encodeURIComponent(collection) + "&indent=" + indentOnDownloadPackage + "&expand-xincludes=" + expandXIncludesOnDownloadPackage + "&omit-xml-declaration=" + omitXMLDeclatarionOnDownloadPackage;
-        fetch(url)
-            .then(resp => resp.blob())
-            .then(blob => {
-                const url = window.URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.style.display = 'none';
-                a.href = url;
-                a.download = decodeURI(collection.split("/").slice(-1)[0]);
-                document.body.appendChild(a);
-                a.click();
-                window.URL.revokeObjectURL(url);
-            })
+        window.location.href = "modules/deployment.xq?download=true&collection=" + encodeURIComponent(collection) + "&indent=" + indentOnDownloadPackage + "&expand-xincludes=" + expandXIncludesOnDownloadPackage + "&omit-xml-decl=" + omitXMLDeclatarionOnDownloadPackage;
     };
     
 	/**

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -290,19 +290,13 @@ eXide.app = (function(util) {
 				$("#open-dialog").dialog("close");
 		},
 
-        downloadSelectedDocument: function(docs, close) {
-			var resources = docs;
+        downloadSelectedResources: function(resources, close) {
 			if (resources) {
-                resources.filter(res => res.isCollection).forEach(collection => {
-                    deploymentEditor.download(collection.key);
-                });
-
-                resources.filter(res => !res.isCollection).forEach(resource => {
+                resources.forEach(resource => {
                     app.download(resource.key);
                 })
-
 			}else {
-                util.Dialog.warning("Invalid selection","The Download Selected command requires that resources be selected. Please select a resources for download.")
+                util.Dialog.warning("Invalid selection","The Download Selected command requires that resources be selected. Please select resources for download.")
             }
 			if (close == undefined || close)
 				$("#open-dialog").dialog("close");

--- a/src/resources.js
+++ b/src/resources.js
@@ -780,7 +780,7 @@ eXide.browse.Browser = (function () {
 		$(button).click(function (ev) {
 			ev.preventDefault();
 			const selected = $this.resources.getSelected();
-			eXide.app.downloadSelectedDocument(selected, false);
+			eXide.app.downloadSelectedResources(selected, false);
 		});
 
         this.btnCopy = createButton(toolbar, "Copy", "copy", 7, "copy");


### PR DESCRIPTION
Fixes #649.

I manually tested the following actions to confirm the expected behavior:

1. With a file that belongs to a package open in the current editor tab, selecting Application > Download app downloads the parent package, named according to the package's metadata defined in its expath-pkg.xml file: `@abbrev` + `-` + `@version` + the `.xar` filename extension.
2. Selecting File > Download downloads the file open in the current editor tab.
3. In File > Manage, selecting one or more resources and/or one or more collections causes the resource(s) to be downloaded as is and the collection(s) to be downloaded zipped.

I lack the skills to craft an automated integration test.