### PR TITLE
Align mime types with eXist 3.0.0+

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -288,12 +288,12 @@ eXide.util.mimeTypes = (function () {
         'xquery': ['application/xquery'],
         'css': ['text/css'],
         'html': ['text/html'],
-        'javascript': ['application/x-javascript'],
+        'javascript': ['application/javascript'],
         'text': ['text/text'],
         'less': ['application/less'],
         'tmsnippet': ['application/tmsnippet'],
         'json': ['application/json'],
-        'markdown': ['text/x-markdown']
+        'markdown': ['text/markdown']
     };
 
     return {


### PR DESCRIPTION
In https://github.com/eXist-db/exist/pull/1136, released with eXist 3.0.0, eXist changed the mime types associated with Javascript and Markdown files. This PR aligns eXide's mime type detection with that PR. With this PR applied, when opening Javascript or Markdown files, eXide will correctly detect the file type and apply syntax highlighting, linting, and other syntax-related features automatically.

Fixes https://github.com/eXist-db/exist/issues/5338 reported by @Speedlearner5.