### PR TITLE
Update serialisation option to include media type

### DIFF
--- a/modules/outline.xq
+++ b/modules/outline.xq
@@ -18,7 +18,7 @@
  :)
 xquery version "3.0";
 
-declare option exist:serialize "method=json indent=yes";
+declare option exist:serialize "method=json media-type=application/json indent=yes";
 
 declare function local:generate-signature($func as element(function)) {
     $func/@name/string() || "(" ||


### PR DESCRIPTION
This fixes the

```
   XML Parsing Error: syntax error
   Location: https://site/exist/apps/eXide/outline
   Line Number 1, Column 1:
```

error in Firefox.