### PR TITLE
feat(run-as-test): pending rendering, setup-failure panel, JUnit download, click-to-jump

### DIFF
--- a/cypress/e2e/run_as_test_results_spec.cy.js
+++ b/cypress/e2e/run_as_test_results_spec.cy.js
@@ -168,6 +168,90 @@ describe('Run as test — results rendering', () => {
     })
   })
 
+  it('%test:pending renders distinct pending row + summary count', () => {
+    var src =
+      'xquery version "3.1";\n' +
+      'module namespace t = "http://example.com/cy-pending";\n' +
+      'declare namespace test = "http://exist-db.org/xquery/xqsuite";\n' +
+      'declare %test:assertEquals(1) function t:passes() { 1 };\n' +
+      'declare %test:pending %test:assertEquals(1) function t:skipped() { 1 };\n'
+
+    runSuite(src).within(() => {
+      cy.get('.test-summary .test-pending').should('contain.text', '1 pending')
+      cy.get('tr.test-pending').should('have.length', 1)
+      cy.get('tr.test-pending').should('contain.text', 'skipped')
+      cy.get('tr.test-pass').should('have.length', 1)
+    })
+  })
+
+  it('setup-failure renders distinct panel instead of empty table', () => {
+    var src =
+      'xquery version "3.1";\n' +
+      'module namespace t = "http://example.com/cy-setup";\n' +
+      'declare namespace test = "http://exist-db.org/xquery/xqsuite";\n' +
+      'declare %test:setUp function t:setup() {\n' +
+      '  error(xs:QName("t:setup-boom"), "setup blew up")\n' +
+      '};\n' +
+      'declare %test:assertEquals(1) function t:never-runs() { 1 };\n'
+
+    runSuite(src).within(() => {
+      cy.get('.test-setup-failure-summary').should('exist')
+      cy.get('.test-setup-failure-label').should('contain.text', 'setUp')
+      cy.get('.test-setup-failure').should('contain.text', 'setup blew up')
+      // Empty results table not shown — the setup panel takes over.
+      cy.get('tbody tr').should('not.exist')
+    })
+  })
+
+  it('JUnit XML download button appears and is wired to a blob', () => {
+    var src =
+      'xquery version "3.1";\n' +
+      'module namespace t = "http://example.com/cy-junit";\n' +
+      'declare namespace test = "http://exist-db.org/xquery/xqsuite";\n' +
+      'declare %test:assertEquals(1) function t:trivial() { 1 };\n'
+
+    runSuite(src).within(() => {
+      cy.get('.test-download-junit').should('be.visible')
+        .and('contain.text', 'JUnit XML')
+    })
+    // Verify the JSON payload carries the serialized xml the button will save.
+    cy.get('@runTest').its('response.body.xml').should('match', /<testsuites/)
+  })
+
+  it('clicking a test row jumps to the annotation line in the editor', () => {
+    var src =
+      'xquery version "3.1";\n' +                                  // 1
+      'module namespace t = "http://example.com/cy-jump";\n' +     // 2
+      'declare namespace test = "http://exist-db.org/xquery/xqsuite";\n' + // 3
+      '\n' +                                                       // 4
+      '\n' +                                                       // 5
+      'declare %test:assertEquals(1) function t:first() { 1 };\n' +  // 6
+      '\n' +                                                       // 7
+      '\n' +                                                       // 8
+      '\n' +                                                       // 9
+      'declare %test:assertEquals(2) function t:second() { 2 };\n'   // 10
+
+    runSuite(src).within(() => {
+      // Rows expose data-source/data-line for the click-to-jump handler.
+      cy.get('tr.test-clickable[data-source]').should('have.length', 2)
+      cy.get('tr.test-clickable').eq(1).should('have.attr', 'data-line')
+        .and('match', /^\d+$/)
+      // Click second-row → editor cursor should move to that line.
+      cy.get('tr.test-clickable').eq(1).then(($row) => {
+        var line = parseInt($row.attr('data-line'), 10)
+        expect(line, 'data-line is a positive int').to.be.greaterThan(0)
+        cy.wrap($row).click()
+        cy.window().then((win) => {
+          var view = win.eXide.app.getEditor().editor
+          var head = view.state.selection.main.head
+          var cursorLine = view.state.doc.lineAt(head).number
+          // CM6 .number is 1-indexed, matching data-line.
+          expect(cursorLine).to.eq(line)
+        })
+      })
+    })
+  })
+
   it('summary surfaces elapsed time when XQSuite reports it', () => {
     // Regression test for the bug where `$result/self::testsuite` never
     // matched the actual <testsuites><testsuite/></testsuites> shape, so

--- a/modules/api/test.xqm
+++ b/modules/api/test.xqm
@@ -37,20 +37,37 @@ declare function test:run($request as map(*)) {
                  : matched, so @tests/@failures/@time/@pending all fell back to 0 or ""
                  : even when XQSuite reported real values. Walk one level down. :)
                 let $testsuite := $result/testsuite
+                (: setUp failure shape: xqsuite emits <testsuite errors="N">message-text</testsuite>
+                 : with no @tests, no @failures, no <testcase> children. We detect that distinct
+                 : shape so the client can render a "Setup Failed" panel instead of an empty table. :)
+                let $setup-failure := if (empty($testsuite/testcase) and string-length(string($testsuite)) > 0) then
+                    map {
+                        "message": string($testsuite),
+                        "errors": xs:integer(($testsuite/@errors, 0)[1])
+                    }
+                else ()
                 return map {
                     "source": $source,
                     "tests": xs:integer(($testsuite/@tests, count($result//testcase))[1]),
                     "failures": xs:integer(($testsuite/@failures, count($result//failure))[1]),
                     "errors": xs:integer(($testsuite/@errors, count($result//error))[1]),
-                    "pending": xs:integer(($testsuite/@pending, 0)[1]),
+                    "pending": xs:integer(($testsuite/@pending, count($result//testcase[pending]))[1]),
                     "time": string(($testsuite/@time, "")[1]),
+                    "setupFailure": $setup-failure,
                     "testcases": array {
                         for $tc in $result//testcase
                         return map {
                             "name": string($tc/@name),
                             "class": string($tc/@class),
                             "line": xs:integer(($tc/@line, 0)[1]),
+                            (: <testcase @source> carries the db path of the module under test —
+                             : needed by the client for "click row to jump to source line" :)
+                            "source": string($tc/@source),
                             "time": string(($tc/@time, "")[1]),
+                            (: %test:pending tests appear as <testcase><pending/></testcase>;
+                             : without a failure or error child they'd render as passing. Surface
+                             : the pending flag so the client can render a distinct row class. :)
+                            "pending": exists($tc/pending),
                             (: XQSuite emits the *expected* value as the body of <failure>
                              : and the *actual* value as a sibling <output> element. Surfacing
                              : only one half left users wondering "expected what?" or

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -4946,6 +4946,21 @@ body.dark #login-error { color: #fc8181; }
 }
 .test-summary .test-failures { color: #c0392b; font-weight: 600; }
 .test-summary .test-errors { color: #c0392b; font-weight: 600; }
+.test-summary .test-pending { color: #8e7300; font-weight: 600; }
+
+/* JUnit XML download button in the summary line */
+.test-summary .test-download-junit {
+    margin-left: 10px;
+    padding: 2px 8px;
+    font-size: 11px;
+    background: #f8f8f8;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    cursor: pointer;
+    color: inherit;
+}
+.test-summary .test-download-junit:hover { background: #eef; border-color: #99c; }
+.test-summary .test-download-junit .fa { margin-right: 4px; }
 
 .test-results {
     width: 100%;
@@ -4966,6 +4981,35 @@ body.dark #login-error { color: #fc8181; }
 .test-results .test-pass td:nth-child(2) { color: #27ae60; }
 .test-results .test-failure td:nth-child(2),
 .test-results .test-error   td:nth-child(2) { color: #c0392b; font-weight: 600; }
+.test-results .test-pending td:nth-child(2) { color: #8e7300; font-weight: 600; }
+
+/* Clickable row affordance: faint hover to signal interactivity */
+.test-results .test-clickable td:first-child {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: rgba(0, 0, 0, 0.2);
+}
+.test-results .test-clickable:hover td:first-child {
+    text-decoration-color: rgba(0, 0, 0, 0.6);
+}
+
+/* Setup-failure panel — distinct from the regular table because there are
+   no testcases to enumerate */
+.test-setup-failure-summary { color: #c0392b; font-weight: 600; }
+.test-setup-failure {
+    margin-top: 8px;
+    padding: 10px;
+    background: #fde8e8;
+    border: 1px solid #f5c2c2;
+    border-radius: 3px;
+    font-size: 12px;
+}
+.test-setup-failure-label { font-weight: 600; margin-bottom: 4px; color: #c0392b; }
+.test-setup-failure .test-full-output {
+    margin: 0;
+    background: #fff;
+    border-color: #e8b8b8;
+}
 
 /* Per-row expandable details for failures/errors */
 .test-results .test-details summary {
@@ -5008,6 +5052,22 @@ body.dark .test-results td { border-bottom-color: #333; }
 body.dark .test-results .test-pass td:nth-child(2) { color: #58d68d; }
 body.dark .test-results .test-failure td:nth-child(2),
 body.dark .test-results .test-error   td:nth-child(2) { color: #ff6b6b; }
+body.dark .test-results .test-pending td:nth-child(2) { color: #f0c674; }
+body.dark .test-summary .test-pending { color: #f0c674; }
+body.dark .test-results .test-clickable td:first-child { text-decoration-color: rgba(255, 255, 255, 0.25); }
+body.dark .test-results .test-clickable:hover td:first-child { text-decoration-color: rgba(255, 255, 255, 0.65); }
+body.dark .test-summary .test-download-junit {
+    background: #2a2a2a;
+    border-color: #444;
+}
+body.dark .test-summary .test-download-junit:hover { background: #333; border-color: #66a; }
+body.dark .test-setup-failure {
+    background: #3a1a1a;
+    border-color: #5a2a2a;
+}
+body.dark .test-setup-failure-summary,
+body.dark .test-setup-failure-label { color: #ff8e8e; }
+body.dark .test-setup-failure .test-full-output { background: #1f1010; border-color: #5a2a2a; color: #ffcccc; }
 body.dark .test-results .test-full-output {
     background: #1f1f1f;
     border-color: #333;

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -1045,6 +1045,10 @@ eXide.edit.XQueryModeHelper = (function () {
                 var results = document.querySelector(".results-container .results");
                 if (results) {
                     results.innerHTML = self.renderTestResults(data);
+                    // Wire up click-to-jump and JUnit download handlers.
+                    // Delegated from the container so we don't refit listeners
+                    // every time the renderer rebuilds innerHTML.
+                    self.wireTestResultsHandlers(results, data, doc);
                 }
             })
             .catch(function(err) {
@@ -1070,17 +1074,44 @@ eXide.edit.XQueryModeHelper = (function () {
         if (data.error) {
             return '<div class="test-error">' + escapeHtml(data.error) + '</div>';
         }
+        // setUp failure shape: xqsuite emits a testsuite with no testcases and
+        // the error text in the element body. Render a distinct "Setup Failed"
+        // panel — the regular table would show "0 tests" which obscures what
+        // actually went wrong.
+        if (data.setupFailure) {
+            return '<div class="test-summary test-setup-failure-summary">' +
+                '<span class="test-errors">setUp failed</span>' +
+                ' — ' + data.setupFailure.errors + ' tests blocked' +
+                '</div>' +
+                '<div class="test-setup-failure">' +
+                '<div class="test-setup-failure-label">Error from %test:setUp function:</div>' +
+                '<pre class="test-full-output">' + escapeHtml(data.setupFailure.message) + '</pre>' +
+                '</div>';
+        }
         var html = '<div class="test-summary">';
         html += '<span class="test-count">' + data.tests + ' tests</span>';
         if (data.failures > 0) html += ', <span class="test-failures">' + data.failures + ' failures</span>';
         if (data.errors > 0) html += ', <span class="test-errors">' + data.errors + ' errors</span>';
+        if (data.pending > 0) html += ', <span class="test-pending">' + data.pending + ' pending</span>';
         if (data.time) html += ' (' + data.time + ')';
+        // JUnit XML download button. data.xml is the raw <testsuites>…</testsuites>
+        // already prepared server-side; we expose it as a blob download so users
+        // can hand the result to CI consumers (GitHub Actions test reporters,
+        // Jenkins, etc.) that expect JUnit-shaped XML.
+        if (data.xml) {
+            html += ' <button type="button" class="test-download-junit" title="Download JUnit XML">' +
+                '<span class="fa fa-download"/> JUnit XML</button>';
+        }
         html += '</div>';
         html += '<table class="test-results"><thead><tr><th>Test</th><th>Status</th><th>Details</th></tr></thead><tbody>';
         if (data.testcases) {
             for (var i = 0; i < data.testcases.length; i++) {
                 var tc = data.testcases[i];
-                var status = tc.failure ? 'failure' : (tc.error ? 'error' : 'pass');
+                // %test:pending appears as <testcase><pending/></testcase> — surfaced as
+                // tc.pending by the server. Without a distinct status the row would render
+                // as a passing test, hiding from the user that the test was intentionally skipped.
+                var status = tc.pending ? 'pending' :
+                    (tc.failure ? 'failure' : (tc.error ? 'error' : 'pass'));
                 // Short summary message + optional full output for failures/errors.
                 // The XQSuite endpoint may return either a string in `.message` /
                 // `.detail` or a structured object with both fields; we surface
@@ -1118,7 +1149,14 @@ eXide.edit.XQueryModeHelper = (function () {
                     }
                     fullOutput = errLines.join('\n');
                 }
-                html += '<tr class="test-' + status + '">';
+                // data-source + data-line let the row act as a "jump to source line" link.
+                // Wired up in wireTestResultsHandlers (delegated click) so we don't re-bind
+                // every render.
+                var rowAttrs = ' class="test-' + status + ' test-clickable"' +
+                    ' data-source="' + escapeHtml(tc.source || '') + '"' +
+                    ' data-line="' + escapeHtml(String(tc.line || 0)) + '"' +
+                    ' title="Click to open source"';
+                html += '<tr' + rowAttrs + '>';
                 html += '<td>' + escapeHtml(tc.name) + '</td>';
                 html += '<td>' + status + '</td>';
                 if (fullOutput) {
@@ -1137,7 +1175,79 @@ eXide.edit.XQueryModeHelper = (function () {
         html += '</tbody></table>';
         return html;
     };
-    
+
+    /**
+     * Wire interactive handlers on a freshly-rendered test results panel.
+     * Delegated from the results container so we attach once per render.
+     *
+     *  - Click on a test row → open the source module at the test's annotation
+     *    line. If the source matches the currently-active document, we just
+     *    jump in-place; otherwise we open the file via the standard resource
+     *    pathway so the user can edit + re-run.
+     *  - Click on "JUnit XML" download → save data.xml as a .xml blob using
+     *    the active document's name as the filename base.
+     *  - Clicks inside <details>/<summary>/<pre> are ignored so users can
+     *    expand failure detail without triggering the jump.
+     */
+    Constr.prototype.wireTestResultsHandlers = function(container, data, currentDoc) {
+        var self = this;
+
+        var downloadBtn = container.querySelector(".test-download-junit");
+        if (downloadBtn && data.xml) {
+            downloadBtn.addEventListener("click", function() {
+                var blob = new Blob([data.xml], { type: "application/xml" });
+                var url = URL.createObjectURL(blob);
+                var a = document.createElement("a");
+                a.href = url;
+                // currentDoc.getName() returns "foo.xqm"; strip the extension and
+                // append "-junit.xml" so the file is easy to find on disk.
+                var base = (currentDoc && currentDoc.getName && currentDoc.getName()) || "tests";
+                a.download = base.replace(/\.[^.]+$/, "") + "-junit.xml";
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            });
+        }
+
+        var tbody = container.querySelector(".test-results tbody");
+        if (tbody) {
+            tbody.addEventListener("click", function(ev) {
+                // Don't intercept clicks inside the expandable details panel — users
+                // need to be able to expand/collapse failure detail without triggering
+                // the row jump.
+                if (ev.target.closest("details") || ev.target.closest("summary")) return;
+                var row = ev.target.closest("tr.test-clickable");
+                if (!row) return;
+                var src = row.getAttribute("data-source");
+                var line = parseInt(row.getAttribute("data-line"), 10) || 0;
+                if (!src) return;
+                self.openTestSource(src, line, currentDoc);
+            });
+        }
+    };
+
+    /**
+     * Open the source module at a specific line. If the target is the document
+     * currently in focus, we just scroll/cursor there (cheap, no roundtrip).
+     * Otherwise we open via the standard resource pathway so it lands in a new
+     * tab and the user can edit + re-run.
+     */
+    Constr.prototype.openTestSource = function(source, line, currentDoc) {
+        var currentPath = currentDoc && currentDoc.getPath && currentDoc.getPath();
+        if (currentPath === source) {
+            editorUtils.gotoLine(this.editor, line || 1, 0, true);
+            return;
+        }
+        var resource = {
+            path: source,
+            name: source.replace(/^.*\//, ""),
+            writable: true,
+            line: line || 1
+        };
+        eXide.app.$doOpenDocument(resource);
+    };
+
     Constr.prototype.createOutline = function(doc, onComplete) {
         var code = doc.getText();
         var basePath = "xmldb:exist://" + (doc.getBasePath ? doc.getBasePath() : "/db");


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

Closes #805.

## Changes

Four enhancements to the "Run as test" results panel:

### 1. `%test:pending` rendering

Pending tests previously rendered as silent passes because the JSON dropped the `<pending/>` child of `<testcase>`. Now:

- Server-side: `pending: exists($tc/pending)` per testcase, plus a `pending` count in the summary (falls back to `count($result//testcase[pending])` if XQSuite doesn't surface `@pending` on `<testsuite>`).
- Client-side: pending rows get `tr.test-pending` (yellow), and the summary line shows `, N pending` when the count is nonzero.

### 2. Setup-failure panel

When `%test:setUp` throws, XQSuite emits `<testsuite errors="N">message-text</testsuite>` with **no `<testcase>` children**. Before this PR that rendered as an empty results table with no clue what went wrong.

- Server-side: detect the distinct shape (`empty($testsuite/testcase) and string-length(string($testsuite)) > 0`) and surface a `setupFailure: { message, errors }` object.
- Client-side: when `setupFailure` is present, render a distinct red "Setup Failed" panel instead of an empty table.

### 3. JUnit XML download

The full `<testsuites>` document XQSuite returns is JUnit-shaped, so downstream CI tooling can consume it directly. We were already serializing it for the result; now we expose it.

- Server-side: include `"xml": $serialized` in the response.
- Client-side: render a "Download JUnit XML" button in the summary line; clicking creates a Blob and triggers a download named after the active document.

### 4. Click-to-jump from test row to source line

Each `<testcase>` already carries `@line` and `@source` (the db path of the module under test). Wire that up:

- Server-side: surface `source` per testcase (the `class` field carries the module *namespace*, not the path — those are different things).
- Client-side: each row gets `data-source` + `data-line` + `tr.test-clickable`. A delegated click handler on the tbody jumps to the annotation line — in-place via `editorUtils.gotoLine` if the source matches the active document, otherwise via `eXide.app.$doOpenDocument(resource)` so the module opens in a new tab. Clicks inside `<details>`/`<summary>` are ignored so users can still expand failure detail without triggering a jump.

## Out of scope: tearDown failures

I'd hoped to mirror the setup-failure panel for `%test:tearDown` failures, but `xqsuite.xql` (lines 138-141 in master) silently discards tearDown errors:

```xquery
let $tearDown := (
    try { $tearDown-call() } catch * { () }
)
return ($result, $tearDown)[1]
```

The error is caught and the empty sequence returned; nothing in the test XML reflects it. There's no hook to surface tearDown failures from eXide alone — filed upstream as eXist-db/exist#6422.

## Testing

Extended `cypress/e2e/run_as_test_results_spec.cy.js` with four new specs covering each behavior above:

- `%test:pending renders distinct pending row + summary count`
- `setup-failure renders distinct panel instead of empty table`
- `JUnit XML download button appears and is wired to a blob`
- `clicking a test row jumps to the annotation line in the editor`

All 10 specs in the file pass (6 pre-existing + 4 new) against an integrated container with the latest existdb-openapi v0.9.5 and Roaster v1.12.0.

```
Run as test — results rendering
  ✓ all-pass module: summary + per-row status, no expanders (1864ms)
  ✓ failure: expected + actual surfaced in expandable detail (478ms)
  ✓ runtime error: type surfaced in detail (806ms)
  ✓ mixed: pass + failure + error in one suite (336ms)
  ✓ %test:assertError (expected throw) counts as pass (919ms)
  ✓ %test:pending renders distinct pending row + summary count (331ms)
  ✓ setup-failure renders distinct panel instead of empty table (304ms)
  ✓ JUnit XML download button appears and is wired to a blob (325ms)
  ✓ clicking a test row jumps to the annotation line in the editor (416ms)
  ✓ summary surfaces elapsed time when XQSuite reports it (321ms)

10 passing (6s)
```