### PR TITLE
fix(deployment): getProjectFor no longer fails on rootless projects

### DIFF
--- a/src/deployment.js
+++ b/src/deployment.js
@@ -63,14 +63,10 @@ eXide.edit.Projects = (function () {
     };
 
     Constr.prototype.getProjectFor = function (collection) {
-        const re = new RegExp("^" + collection);
-        for (const k in this.projects) {
-            const project = this.projects[k];
-            if (collection.substring(0, project.root.length) === project.root) {
-                return project;
-            }
-        }
-        return null;
+        const filteredProjects = Object.values(this.projects)
+            .filter(project => project &&  project.root && collection.startsWith(project.root));
+
+        return filteredProjects[0] || null;
     };
 
     Constr.prototype.saveState = function () {


### PR DESCRIPTION
closes #809

Filter all projects that do not have a root property before filtering based on it. This caused the function to throw an exception which ultimately prevented documents to be opened.

The method deplyoment#getProjectFor was rewritten for maintainability and readability.