### PR TITLE
fix(auth): derive identity from sm:id(), not the persistent-login attribute

### DIFF
--- a/cypress/e2e/auth_spec.cy.js
+++ b/cypress/e2e/auth_spec.cy.js
@@ -133,3 +133,53 @@ describe('login using form', function () {
     })
 
 })
+
+// GET /api/auth/whoami must report identity from the eXist subject (sm:id()),
+// not the persistent-login request attribute. The attribute is only populated
+// by the cookie/param flow, so before this fix a request authenticated with the
+// HTTP Basic header reported as "guest" even though it executed as the real
+// user. These assert identity is consistent across all three auth mechanisms.
+describe('whoami identity source (sm:id, not the login attribute)', function () {
+    const whoami = '/eXide/api/auth/whoami'
+
+    it('reports the real user under HTTP Basic auth (regression)', function () {
+        cy.request({
+            url: whoami,
+            auth: { user: 'admin', pass: '' }
+        }).then((res) => {
+            expect(res.body.user).to.eq('admin')
+            expect(res.body.isLoggedIn).to.eq(true)
+            expect(res.body.isAdmin).to.eq(true)
+        })
+    })
+
+    it('reports guest when unauthenticated', function () {
+        // Cypress shares a cookie jar across requests; clear it so no
+        // remember-me cookie leaks into this assertion.
+        cy.clearCookies()
+        cy.request({ url: whoami }).then((res) => {
+            expect(res.body.user).to.eq('guest')
+            expect(res.body.isLoggedIn).to.eq(false)
+            expect(res.body.isAdmin).to.eq(false)
+        })
+    })
+
+    it('reports the real user via the persistent-login cookie', function () {
+        cy.clearCookies()
+        // Mint the cookie the way the login form does (form params).
+        cy.request({
+            method: 'POST',
+            url: '/eXide/api/auth/session',
+            form: true,
+            body: { user: 'admin', password: '' }
+        }).then((res) => {
+            expect(res.body.user).to.eq('admin')
+        })
+        // Subsequent request carries the cookie; whoami must agree.
+        cy.request({ url: whoami }).then((res) => {
+            expect(res.body.user).to.eq('admin')
+            expect(res.body.isLoggedIn).to.eq(true)
+            expect(res.body.isAdmin).to.eq(true)
+        })
+    })
+})

--- a/modules/api/auth.xqm
+++ b/modules/api/auth.xqm
@@ -5,16 +5,35 @@ xquery version "3.1";
 
 module namespace auth="http://exist-db.org/apps/eXide/api/auth";
 
-import module namespace login="http://exist-db.org/xquery/login"
-    at "resource:org/exist/xquery/modules/persistentlogin/login.xql";
 import module namespace roaster="http://e-editiones.org/roaster";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
 
-declare variable $auth:LOGIN_DOMAIN := "org.exist.login";
-
-declare function auth:get-user() as xs:string? {
-    let $_ := login:set-user($auth:LOGIN_DOMAIN, xs:dayTimeDuration("P7D"), false())
-    return request:get-attribute($auth:LOGIN_DOMAIN || ".user")
+(:~
+ : The current request's identity, derived from the actual eXist subject
+ : (`sm:id()`) rather than the persistent-login request attribute.
+ :
+ : This matters: the attribute (`org.exist.login.user`) is populated only by
+ : the persistent-login flow (login form params or the remember-me cookie), so
+ : a request authenticated by the HTTP Basic header reported as `guest` even
+ : though it executed as the real user. `sm:id()` reflects whatever
+ : authenticated the request — Basic header, the shared `org.exist.login`
+ : cookie (processed by controller.xq before this handler runs), or a freshly
+ : minted login session — uniformly. This is the same identity basis used by
+ : Roaster's `rutil:getDBUser()` and by existdb-openapi, so eXide's notion of
+ : "who" now matches the rest of the stack.
+ :
+ : `sm:effective` is preferred over `sm:real` because token/cookie logins set
+ : the effective user (same reasoning as Roaster's getDBUser).
+ :)
+declare function auth:current-user() as map(*) {
+    let $id := sm:id()/sm:id
+    let $principal := ($id/sm:effective, $id/sm:real)[1]
+    let $name := ($principal/sm:username/string(), "guest")[1]
+    return map {
+        "name": $name,
+        "isAdmin": sm:is-dba($name),
+        "isLoggedIn": not($name = ("guest", "nobody"))
+    }
 };
 
 declare function auth:is-allowed($user as xs:string?) as xs:boolean {
@@ -27,14 +46,18 @@ declare function auth:is-allowed($user as xs:string?) as xs:boolean {
 
 (:~
  : POST /api/auth/session — Login.
+ :
+ : The persistent-login cookie is minted by controller.xq's `login:set-user`,
+ : which reads the `user` / `password` / `duration` form parameters before
+ : forwarding here. This handler reports the resulting identity.
  :)
 declare function auth:login($request as map(*)) {
-    let $user := auth:get-user()
+    let $user := auth:current-user()
     return
-        if (auth:is-allowed($user)) then
+        if (auth:is-allowed($user?name)) then
             map {
-                "user": ($user, "guest")[1],
-                "isAdmin": sm:is-dba(($user, "guest")[1])
+                "user": $user?name,
+                "isAdmin": $user?isAdmin
             }
         else
             roaster:response(401, "application/json",
@@ -57,15 +80,14 @@ declare function auth:logout($request as map(*)) {
  : GET /api/auth/whoami — Current user info.
  :)
 declare function auth:whoami($request as map(*)) {
-    let $user := auth:get-user()
+    let $user := auth:current-user()
     let $conf := config:get-configuration()
-    let $user-to-check := ($user, "guest")[1]
     return map {
-        "user": $user-to-check,
-        "isAdmin": sm:is-dba($user-to-check),
-        "isLoggedIn": exists($user) and not($user = ("guest", "nobody")),
-        "queryExecution": sm:is-dba($user-to-check) or (
-            $conf/restrictions/@execute-query = "yes" and auth:is-allowed($user)
+        "user": $user?name,
+        "isAdmin": $user?isAdmin,
+        "isLoggedIn": $user?isLoggedIn,
+        "queryExecution": $user?isAdmin or (
+            $conf/restrictions/@execute-query = "yes" and auth:is-allowed($user?name)
         )
     }
 };


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

`GET /api/auth/whoami` and `POST /api/auth/session` now derive identity from the actual eXist subject (`sm:id()`) instead of the persistent-login request attribute (`org.exist.login.user`).

## The bug

The attribute is populated only by the persistent-login flow (login-form params or the remember-me cookie). A request authenticated with the **HTTP Basic header** therefore reported as `guest` even though it *executed* as the real user:

```
# before
curl -u admin:'' …/eXide/api/auth/whoami  →  { "user": "guest",  "isLoggedIn": false, "isAdmin": false }
# after
curl -u admin:'' …/eXide/api/auth/whoami  →  { "user": "admin",  "isLoggedIn": true,  "isAdmin": true  }
```

This also made eXide's notion of "who is logged in" diverge from existdb-openapi's and from Roaster's own `rutil:getDBUser()` — both of which read `sm:id()`. Aligning on `sm:id()` puts eXide on the same identity basis as the rest of the stack.

## Why `sm:id()` is correct here

eXide's `controller.xq` calls `login:set-user` on every request before forwarding to the Roaster handlers, so by the time a handler runs the eXist subject already reflects whatever authenticated the request — Basic header, the shared `org.exist.login` cookie (which is `Path=/exist`, so it reaches every app under `/exist`), or a freshly minted login session. `sm:id()` reads that subject uniformly; the attribute does not. `sm:effective` is preferred over `sm:real` (cookie/token logins set the effective user — same reasoning as Roaster's `getDBUser`).

## Changes

- `modules/api/auth.xqm` — replaced the attribute-based `auth:get-user()` with `auth:current-user()` (reads `sm:id()`, effective-preferred); `whoami`/`login` now use it. Removed the now-unused `login` module import. Response shapes unchanged.
- `cypress/e2e/auth_spec.cy.js` — new `whoami identity source` block: asserts the real user is reported under Basic auth (the regression), guest when unauthenticated, and the real user via the persistent-login cookie.

## Verification

- `auth_spec.cy.js`: 16/16 (was 13).
- **Full eXide suite: 263 passing, 0 failing, 2 intentional skips — all 36 specs green** (with eXist-db/existdb-openapi#46 deployed; see dependency note below).
- Manual: whoami correct under Basic, cookie, unauthenticated, and login-POST. Additionally verified with a temporary **non-empty-password** user (`betatester`): correct identity under Basic and cookie, correctly reported `isAdmin:false` for the non-dba account, and a wrong password did **not** authenticate — confirming the fix is not an artifact of the default empty admin password.

## Cross-repo dependency note

Two eXide specs (`query_error_display`, `query_error_structured`) assert that a failed query surfaces a real error. They pass only when the deployed existdb-openapi includes the fix in **eXist-db/existdb-openapi#46** (the 0.9.7 `/api/query` regression that returned HTTP 200 + "Invalid context-item" for genuine query errors). Against a stock 0.9.7 those two specs fail. So eXide's green suite currently depends on eXist-db/existdb-openapi#46 landing and a 0.9.8 release — **worth prioritizing**.

## Scope note (deliberate, not in this PR)

This is the beachhead of a larger consolidation (existdb-openapi as the single backend; stock apps as thin clients on a common `sm:id()` identity baseline). Natural follow-ups, each its own verified step:

1. Remove the `security: []` overrides on the two `/api/auth/*` routes so they participate in Roaster's `standard-authorization` middleware and read `$request?user` directly (full convergence; deferred because it brings the login POST under CSRF and wants its own validation).
2. Retire eXide's legacy `controller.xq` `/login` branch in favour of `/api/auth/session`.
3. Apply the same `sm:id()` identity fix to `documentation-next` (also reads the attribute); `dashboard-next` already reads `$request?user`.
4. Parametrize the cypress suites onto a **non-empty admin password** so credential-handling bugs can't hide behind the empty-string default (touches test config in both eXide and existdb-openapi — worth doing deliberately).
