### PR TITLE
fix(db): adapt /api/storage onto existdb-openapi db-core (held)

### DIFF
--- a/cypress/e2e/db_resource_adapter_spec.cy.js
+++ b/cypress/e2e/db_resource_adapter_spec.cy.js
@@ -1,0 +1,204 @@
+// Coverage for the db-core adapter (modules/api/db.xqm) — the paths the broader
+// suite leaves unguarded. The adapter delegates /api/storage to existdb-openapi's
+// db-core in-process; db-core's get-resource no longer bundles metadata (meta=full
+// is gone) so db:load re-sources owner/group/mode/last-modified from dbc:properties.
+// These tests assert that re-sourced metadata reaches the real consumers, plus the
+// serialization, ?download, db:patch, and resource-delete branches.
+
+const COLLECTION = '/db/cypress-dbcore'
+const XML_DOC = COLLECTION + '/meta.xml'
+const BLOB_DOC = COLLECTION + '/blob.bin'
+const PATCH_DOC = COLLECTION + '/patch.xml'
+const DEL_DOC = COLLECTION + '/del.xml'
+const XML_BODY = '<a><b>x</b><c>y</c></a>'
+const BLOB_BODY = 'BINARYBLOB1234'
+
+// /eXide/api/storage URL with each path segment encoded (mirrors the frontend).
+function storageUrl(dbPath) {
+  return '/eXide/api/storage/' + dbPath.replace(/^\//, '').split('/').map(encodeURIComponent).join('/')
+}
+
+function putResource(dbPath, body, contentType) {
+  return cy.request({
+    method: 'PUT',
+    url: storageUrl(dbPath),
+    headers: { 'Content-Type': contentType },
+    body
+  })
+}
+
+function cleanup() {
+  cy.loginXHR('admin', '')
+  // Adapter DELETE -> db:delete -> dbc:remove-collection (tolerate a missing collection)
+  cy.request({ method: 'DELETE', url: storageUrl(COLLECTION), failOnStatusCode: false })
+}
+
+context('DB resource adapter (db-core)', () => {
+  before(() => {
+    cleanup()
+    cy.loginXHR('admin', '')
+    // Seed via the adapter's own PUT (db:put -> dbc:store) so store coverage is real.
+    cy.request({
+      method: 'POST',
+      url: storageUrl('/db'),
+      headers: { 'Content-Type': 'application/json' },
+      body: { action: 'create', name: 'cypress-dbcore' }
+    })
+    putResource(XML_DOC, XML_BODY, 'application/xml')
+    putResource(PATCH_DOC, XML_BODY, 'application/xml')
+    putResource(DEL_DOC, XML_BODY, 'application/xml')
+    // octet-stream content lands as a true binary doc, so the binary download
+    // branch (util:binary-doc -> stream-binary) is exercised.
+    putResource(BLOB_DOC, BLOB_BODY, 'application/octet-stream')
+  })
+
+  after(() => { cleanup() })
+
+  beforeEach(() => { cy.loginXHR('admin', '') })
+
+  describe('db:load envelope (dbc:get-resource + dbc:properties)', () => {
+    it('store (dbc:store) reports the stored path', () => {
+      putResource(XML_DOC, XML_BODY, 'application/xml').then((r) => {
+        expect(r.body).to.have.property('status', 'ok')
+        expect(r.body).to.have.property('path', XML_DOC)
+      })
+    })
+
+    it('GET an XML resource carries metadata re-sourced from dbc:properties', () => {
+      cy.request(storageUrl(XML_DOC)).then((r) => {
+        // get-resource shape { path, binary, content, mime-type }
+        expect(r.body).to.have.property('path', XML_DOC)
+        expect(r.body).to.have.property('binary', false)
+        expect(r.body).to.have.property('mime', 'application/xml')
+        expect(r.body.content).to.contain('<a>')
+        // owner/group/mode/last-modified now come from dbc:properties, not meta=full
+        expect(r.body).to.have.property('owner', 'admin')
+        expect(r.body).to.have.property('group', 'dba')
+        expect(r.body.permissions).to.match(/^rw.r..r../)
+        expect(r.body.lastModified).to.match(/^\d{4}-\d\d-\d\dT/)
+        // externalPath is eXide-derived (context-path aware), not db-core's dropped runPath
+        expect(r.body).to.have.property('externalPath', '/exist/rest/db/cypress-dbcore/meta.xml')
+      })
+    })
+  })
+
+  describe('serialization params driven through db:load', () => {
+    it('indent=false flattens, indent=true pretty-prints, and they differ', () => {
+      cy.request(storageUrl(XML_DOC) + '?indent=false').then((flat) => {
+        expect(flat.body.content).to.eq(XML_BODY)
+        cy.request(storageUrl(XML_DOC) + '?indent=true').then((pretty) => {
+          expect(pretty.body.content).to.contain('\n')
+          expect(pretty.body.content).to.not.eq(flat.body.content)
+        })
+      })
+    })
+
+    it('omit-xml-decl=false includes the XML declaration', () => {
+      cy.request(storageUrl(XML_DOC) + '?omit-xml-decl=false').then((r) => {
+        expect(r.body.content).to.match(/^<\?xml/)
+      })
+      cy.request(storageUrl(XML_DOC) + '?omit-xml-decl=true').then((r) => {
+        expect(r.body.content).to.not.contain('<?xml')
+      })
+    })
+  })
+
+  describe('?download raw streaming', () => {
+    it('downloads an XML doc as application/xml bytes', () => {
+      cy.request(storageUrl(XML_DOC) + '?download=true').then((r) => {
+        expect(r.status).to.eq(200)
+        expect(r.headers['content-type']).to.contain('application/xml')
+        expect(r.body).to.contain('<b>x</b>')
+      })
+    })
+
+    it('downloads a binary doc as raw octet-stream bytes', () => {
+      cy.request({ url: storageUrl(BLOB_DOC) + '?download=true', encoding: 'binary' }).then((r) => {
+        expect(r.status).to.eq(200)
+        expect(r.headers['content-type']).to.contain('application/octet-stream')
+        expect(r.body).to.eq(BLOB_BODY)
+      })
+    })
+  })
+
+  describe('properties dialog reflects dbc:properties metadata', () => {
+    it('shows owner/group/mode for a true XML resource', () => {
+      cy.visit('/eXide/index.html', {
+        onBeforeLoad(win) { win.localStorage.setItem('eXide.firstTime', '0') }
+      })
+      cy.dismissDialog()
+      cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a').click()
+      cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul').find('#menu-file-manager').click()
+      cy.get('div.eXide-browse-main').within(() => {
+        cy.contains('.browse-table tbody td.col-name', 'cypress-dbcore').dblclick()
+        cy.contains('.browse-table tbody td.col-name', 'meta.xml').click()
+      })
+      cy.get('#eXide-browse-toolbar-properties').click()
+
+      cy.get('#resource-properties-content').within(() => {
+        // owner/group selects carry the values db:load sourced from dbc:properties
+        cy.get('select[name="owner"]').should('have.value', 'admin')
+        cy.get('select[name="group"]').should('have.value', 'dba')
+        // permission checkboxes reflect mode rw-r--r--
+        cy.get('#ur').should('be.checked')
+        cy.get('#uw').should('be.checked')
+        cy.get('#ux').should('not.be.checked')
+        cy.get('#gr').should('be.checked')
+        cy.get('#gw').should('not.be.checked')
+        cy.get('#or').should('be.checked')
+        cy.get('#ow').should('not.be.checked')
+      })
+    })
+  })
+
+  describe('db:patch (dbc:set-permissions) via the properties dialog', () => {
+    it('Apply changes the mode, confirmed by a re-read', () => {
+      cy.visit('/eXide/index.html', {
+        onBeforeLoad(win) { win.localStorage.setItem('eXide.firstTime', '0') }
+      })
+      cy.dismissDialog()
+      cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a').click()
+      cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul').find('#menu-file-manager').click()
+      // Navigate into the test collection and open properties for patch.xml
+      cy.get('div.eXide-browse-main').within(() => {
+        cy.contains('.browse-table tbody td.col-name', 'cypress-dbcore').dblclick()
+        cy.contains('.browse-table tbody td.col-name', 'patch.xml').click()
+      })
+      cy.get('#eXide-browse-toolbar-properties').click()
+
+      const dialog = () => cy.get('#resource-properties-dialog').closest('dialog.eXide-dialog[open]')
+      // Default mode is rw-r--r-- : group-write starts unchecked
+      dialog().find('#gw').should('not.be.checked').check()
+      dialog().contains('.eXide-dialog-buttons button', 'Apply').click()
+
+      // db:patch -> dbc:set-permissions; verify the new mode through db:load
+      cy.request(storageUrl(PATCH_DOC)).then((r) => {
+        expect(r.body.permissions).to.eq('rw-rw-r--')
+      })
+    })
+  })
+
+  describe('resource-level delete (dbc:remove-resource)', () => {
+    it('deletes a single resource via the db manager', () => {
+      cy.visit('/eXide/index.html', {
+        onBeforeLoad(win) { win.localStorage.setItem('eXide.firstTime', '0') }
+      })
+      cy.dismissDialog()
+      cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a').click()
+      cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul').find('#menu-file-manager').click()
+      cy.get('div.eXide-browse-main').within(() => {
+        cy.contains('.browse-table tbody td.col-name', 'cypress-dbcore').dblclick()
+        cy.contains('.browse-table tbody td.col-name', 'del.xml').click()
+      })
+      cy.get('#eXide-browse-toolbar-delete-resource').click()
+      cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
+      cy.get('div.eXide-browse-main').within(() => {
+        cy.contains('.browse-table tbody td.col-name', 'del.xml').should('not.exist')
+      })
+      // Confirmed gone at the adapter level too
+      cy.request({ url: storageUrl(DEL_DOC), failOnStatusCode: false }).then((r) => {
+        expect(r.status).to.eq(404)
+      })
+    })
+  })
+})

--- a/modules/api.json
+++ b/modules/api.json
@@ -139,13 +139,6 @@
                         }
                     },
                     {
-                        "name": "filter",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
                         "name": "download",
                         "in": "query",
                         "schema": {

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -239,17 +239,18 @@ declare %private function db:load($wire as xs:string, $stored as xs:string, $req
             roaster:response(404, "application/json",
                 map { "error": "Not found or no read access" })
         else if ($download) then
-            (: Binary download: stream the raw bytes with response:stream-binary —
-               the same path roaster's own test app uses. roaster:response(…, bytes)
-               would run the value through the serializer and emit its base64 TEXT
-               (corrupting the file); response:stream-binary writes the bytes. XML
-               download serializes via db-core (a text string), so roaster:response
-               is correct there. :)
+            (: Download streams raw bytes with response:stream-binary — the path
+               roaster's own test app uses. roaster:response(…) would run the value
+               through the serializer: for a binary value it emits base64 TEXT
+               (corrupting the file), and for a serialized-XML STRING under an xml
+               mime it escapes the angle brackets a second time. So in both cases we
+               stream bytes: binary docs directly, XML/text via db-core's serialized
+               string (which honors indent/omit-xml-decl) converted to bytes. :)
             if (util:binary-doc-available($stored)) then
                 util:binary-doc($stored) => response:stream-binary($mime, ())
             else
                 let $r := dbc:get-resource($wire, db:ser-opts($request))
-                return roaster:response(200, $mime, $r?content)
+                return util:string-to-binary($r?content) => response:stream-binary($mime, ())
         else if (util:binary-doc-available($stored)) then
             db:load-binary($stored, $mime)
         else

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -13,8 +13,9 @@
  :  What stays eXide-side for now (progressively migrating as db-core grows):
  :   - binary load + ?download raw streaming (db-core's binary handling is cruder;
  :     full transport is existdb-openapi#38, the Roaster streaming track);
- :   - externalPath, computed eXide's way (context-path aware), overriding
- :     db-core's runPath.
+ :   - externalPath, computed eXide's way (context-path aware). db-core no longer
+ :     returns a runPath; the executable URL is client-derived, and eXide keeps its
+ :     own context-path-aware computation rather than the generic /exist form.
  :
  :  Naming convention: this adapter speaks DECODED paths to db-core, which applies
  :  fn:iri-to-uri internally — so it adopts existdb-openapi's resource-naming
@@ -219,12 +220,14 @@ declare %private function db:to-exide-item($c as map(*)) as map(*) {
 };
 
 (:~
- : Load a document. XML (non-download) delegates to db-core:get-resource —
- : including serialization (method/indent/omit-xml-declaration via #48, folded
- : into db-core) and metadata (meta=full). Binary load and ?download raw
- : streaming stay eXide-side until existdb-openapi#38's Roaster transport lands.
- : externalPath is computed eXide's way (context-path aware), overriding
- : db-core's runPath.
+ : Load a document. XML (non-download) delegates to db-core:get-resource for the
+ : serialized content (method/indent/omit-xml-declaration via #48, folded into
+ : db-core) and to db-core:properties for owner/perms/timestamps — the
+ : consolidated db-core (existdb-openapi#59) no longer bundles metadata in
+ : get-resource, which returns just { path, binary, content, mime-type }. Binary
+ : load and ?download raw streaming stay eXide-side until existdb-openapi#38's
+ : Roaster transport lands. externalPath is computed eXide's way (context-path
+ : aware); db-core no longer returns a runPath.
  :
  : eXide's serialization param names are translated to db-core's: omit-xml-decl
  : -> omit-xml-declaration. expand-xincludes is intentionally not forwarded — it
@@ -254,18 +257,18 @@ declare %private function db:load($wire as xs:string, $stored as xs:string, $req
         else if (util:binary-doc-available($stored)) then
             db:load-binary($stored, $mime)
         else
-            let $r := dbc:get-resource($wire,
-                map:merge((db:ser-opts($request), map { "meta": "full" })))
+            let $r := dbc:get-resource($wire, db:ser-opts($request))
+            let $props := dbc:properties($wire)
             return map {
                 "path": $r?path,
                 "mime": $r?("mime-type"),
                 "binary": false(),
                 "externalPath": db:get-run-path($stored),
                 "content": $r?content,
-                "lastModified": $r?("last-modified"),
-                "permissions": $r?mode,
-                "owner": $r?owner,
-                "group": $r?group
+                "lastModified": $props?("last-modified"),
+                "permissions": $props?mode,
+                "owner": $props?owner,
+                "group": $props?group
             }
 };
 

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -1,272 +1,312 @@
 (:
  :  eXide REST API — Database resource handlers.
- :  Migrated from collections.xq, load.xq, store.xq.
+ :
+ :  Thin ADAPTER over existdb-openapi's roaster-independent db-core module: the
+ :  /api/storage surface and eXide's response shapes are kept identical (the
+ :  frontend is untouched), but all resource CRUD + naming correctness is
+ :  delegated in-process to db-core (imported by namespace; existdb-openapi is a
+ :  declared dependency). No HTTP hop, no re-auth — db-core runs as the current
+ :  request user. This makes existdb-openapi the single audited implementation of
+ :  db resource handling; eXide stops carrying its own xmldb:store/doc()/encode
+ :  logic.
+ :
+ :  What stays eXide-side for now (progressively migrating as db-core grows):
+ :   - binary load + ?download raw streaming (db-core's binary handling is cruder;
+ :     full transport is existdb-openapi#38, the Roaster streaming track);
+ :   - externalPath, computed eXide's way (context-path aware), overriding
+ :     db-core's runPath.
+ :
+ :  Naming convention: this adapter speaks DECODED paths to db-core, which applies
+ :  fn:iri-to-uri internally — so it adopts existdb-openapi's resource-naming
+ :  convention (sub-delims left literal, e.g. it's.xml) rather than eXide's former
+ :  full-encode (it%27s.xml). The cutover of this convention is gated on the
+ :  resource-naming contract decision.
  :)
 xquery version "3.1";
 
 module namespace db="http://exist-db.org/apps/eXide/api/db";
 
 import module namespace roaster="http://e-editiones.org/roaster";
-import module namespace dbutil="http://exist-db.org/xquery/dbutil" at "../dbutils.xqm";
-import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
+(: db-core: imported by namespace — existdb-openapi is a declared dependency
+ : (expath-pkg.xml) and registers db-core as a public XQuery module. :)
+import module namespace dbc="http://exist-db.org/api/db-core";
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace sm="http://exist-db.org/xquery/securitymanager";
 
-(: Handle difference between 4.x.x and 5.x.x releases of eXist :)
-declare variable $db:copy-collection :=
-    let $fnNew := function-lookup(xs:QName("xmldb:copy-collection"), 2)
-    return
-        if (exists($fnNew)) then $fnNew else function-lookup(xs:QName("xmldb:copy"), 2);
+(:~
+ : Map a typed db-core error to an eXide HTTP response. db-core signals failures
+ : as typed errors in http://exist-db.org/api/db-core/error; the local-name picks
+ : the status, $err:description becomes the message, $err:value (a map) adds any
+ : extra fields (move/copy partial-state hints). Unknown codes fall through to 500.
+ :)
+declare %private function db:error-response(
+    $code as xs:QName, $description as xs:string?, $value as item()*
+) {
+    let $status :=
+        (map {
+            "bad-request": 400,
+            "forbidden": 403,
+            "not-found": 404,
+            "conflict": 409,
+            "server-error": 500
+        }(local-name-from-QName($code)), 500)[1]
+    let $extra := if ($value instance of map(*)) then $value else map {}
+    return roaster:response($status, "application/json",
+        map:merge((map { "error": $description }, $extra)))
+};
 
-declare variable $db:copy-resource :=
-    let $fnNew := function-lookup(xs:QName("xmldb:copy-resource"), 4)
-    return
-        if (exists($fnNew)) then $fnNew
-        else
-            let $fnOld := function-lookup(xs:QName("xmldb:copy"), 3)
-            return function($sourceCol, $sourceName, $targetCol, $targetName) {
-                $fnOld($sourceCol, $targetCol, $sourceName)
-            };
+(:~ The decoded wire path for a {path} route parameter. :)
+declare %private function db:wire($request as map(*)) as xs:string {
+    "/" || $request?parameters?path
+};
 
 (:~
  : GET /api/storage/{path} — Browse collection or load document.
  :)
 declare function db:get($request as map(*)) {
-    let $path := db:encode-path("/" || $request?parameters?path)
-    let $user := (request:get-attribute("org.exist.login.user"), "guest")[1]
-    return
-        if (xmldb:collection-available($path)) then
-            db:browse-collection($path, $request, $user)
-        else if (doc-available($path) or util:binary-doc-available($path)) then
-            db:load-document($path, $request, $user)
-        else
-            roaster:response(404, "application/json",
-                map { "error": "Not found: " || $path })
-};
-
-(:~
- : PUT /api/storage/{path} — Create or update document.
- :)
-declare function db:put($request as map(*)) {
-    let $path := db:encode-path("/" || $request?parameters?path)
-    let $data := $request?body
-    let $collection := replace($path, "/[^/]+$", "")
-    let $resource := replace($path, "^.*/", "")
+    let $wire := db:wire($request)
+    let $stored := dbc:to-stored($wire)
     return
         try {
-            let $stored := xs:anyURI(xmldb:store($collection, $resource, $data))
-            (: Fix permissions for XQuery files :)
-            let $mime := xmldb:get-mime-type($stored)
-            let $_ :=
-                if ($mime = "application/xquery") then
-                    sm:chmod($stored, "rwxr-xr-x")
-                else ()
-            return map {
-                "status": "ok",
-                "path": $stored
-            }
+            if (xmldb:collection-available($stored)) then
+                db:browse($wire, $request)
+            else if (doc-available($stored) or util:binary-doc-available($stored)) then
+                db:load($wire, $stored, $request)
+            else
+                roaster:response(404, "application/json",
+                    map { "error": "Not found: " || dbc:to-display($stored) })
         } catch * {
-            roaster:response(400, "application/json",
-                map { "error": $err:description })
+            db:error-response($err:code, $err:description, $err:value)
         }
 };
 
 (:~
- : POST /api/storage/{path} — Create subcollection or batch operations.
- : Body: { "action": "create" | "copy" | "move" | "rename", ... }
+ : PUT /api/storage/{path} — Create or update document. Body is the raw content.
+ :)
+declare function db:put($request as map(*)) {
+    try {
+        (: mime omitted -> db-core lets eXist infer from the name (3-arg xmldb:store) :)
+        let $r := dbc:store(db:wire($request), $request?body, ())
+        return map { "status": "ok", "path": $r?stored }
+    } catch * {
+        db:error-response($err:code, $err:description, $err:value)
+    }
+};
+
+(:~
+ : POST /api/storage/{path} — Create subcollection or batch copy/move/rename.
+ : Body: { "action": "create" | "copy" | "move" | "rename", … }
  :)
 declare function db:post($request as map(*)) {
-    let $path := db:encode-path("/" || $request?parameters?path)
+    let $wire := db:wire($request)
     let $body := $request?body
     let $action := $body?action
     return
-        switch ($action)
-            case "create" return
-                try {
-                    let $name := $body?name
-                    let $created := xmldb:create-collection($path, $name)
-                    return map { "status": "ok", "path": $created }
-                } catch * {
-                    roaster:response(400, "application/json",
-                        map { "error": $err:description })
-                }
-            case "copy" return
-                try {
-                    let $sources := $body?sources?*
+        try {
+            switch ($action)
+                case "create" return
+                    let $r := dbc:create-collection($wire || "/" || $body?name)
+                    return map { "status": "ok", "path": $r?created }
+                case "copy" return
                     let $_ :=
-                        for $source in $sources
-                        let $enc-source := db:encode-path($source)
-                        return
-                            if (xmldb:collection-available($enc-source)) then
-                                $db:copy-collection($enc-source, $path)
-                            else
-                                let $name := replace($enc-source, "^.*/", "")
-                                let $src-col := replace($enc-source, "/[^/]+$", "")
-                                return $db:copy-resource($src-col, $name, $path, $name)
+                        for $source in $body?sources?*
+                        return dbc:copy(map { "source": $source, "parent": $wire })
                     return map { "status": "ok" }
-                } catch * {
+                case "move" return
+                    let $_ :=
+                        for $source in $body?sources?*
+                        return dbc:move(map { "source": $source, "parent": $wire })
+                    return map { "status": "ok" }
+                case "rename" return
+                    let $_ := dbc:move(map { "source": $wire, "newName": $body?target })
+                    return map { "status": "ok" }
+                default return
                     roaster:response(400, "application/json",
-                        map { "error": $err:description })
-                }
-            case "move" return
-                try {
-                    let $sources := $body?sources?*
-                    for $source in $sources
-                    let $enc-source := db:encode-path($source)
-                    return
-                        if (xmldb:collection-available($enc-source)) then
-                            xmldb:move($enc-source, $path)
-                        else
-                            let $name := replace($enc-source, "^.*/", "")
-                            let $src-col := replace($enc-source, "/[^/]+$", "")
-                            return xmldb:move($src-col, $path, $name)
-                    ,
-                    map { "status": "ok" }
-                } catch * {
-                    roaster:response(400, "application/json",
-                        map { "error": $err:description })
-                }
-            case "rename" return
-                try {
-                    let $target := $body?target
-                    return
-                        if (xmldb:collection-available($path)) then (
-                            xmldb:rename($path, $target),
-                            map { "status": "ok" }
-                        )
-                        else
-                            let $col := replace($path, "/[^/]+$", "")
-                            let $name := replace($path, "^.*/", "")
-                            return (
-                                xmldb:rename($col, $name, $target),
-                                map { "status": "ok" }
-                            )
-                } catch * {
-                    roaster:response(400, "application/json",
-                        map { "error": $err:description })
-                }
-            default return
-                roaster:response(400, "application/json",
-                    map { "error": "Unknown action: " || $action })
+                        map { "error": "Unknown action: " || $action })
+        } catch * {
+            db:error-response($err:code, $err:description, $err:value)
+        }
 };
 
 (:~
  : DELETE /api/storage/{path} — Delete resource or collection.
  :)
 declare function db:delete($request as map(*)) {
-    let $path := db:encode-path("/" || $request?parameters?path)
-    return
-        try {
-            if (xmldb:collection-available($path)) then (
-                xmldb:remove($path),
-                map { "status": "ok" }
-            )
-            else
-                let $col := replace($path, "/[^/]+$", "")
-                let $name := replace($path, "^.*/", "")
-                return (
-                    xmldb:remove($col, $name),
-                    map { "status": "ok" }
-                )
-        } catch * {
-            roaster:response(400, "application/json",
-                map { "error": $err:description })
-        }
+    try {
+        let $wire := db:wire($request)
+        let $stored := dbc:to-stored($wire)
+        let $_ :=
+            if (xmldb:collection-available($stored))
+            (: force=true mirrors eXide's recursive delete; db-core also guards the
+             : protected paths (/db, /db/apps, /db/system) with a 403. :)
+            then dbc:remove-collection($wire, true())
+            else dbc:remove-resource($wire)
+        return map { "status": "ok" }
+    } catch * {
+        db:error-response($err:code, $err:description, $err:value)
+    }
 };
 
 (:~
  : PATCH /api/storage/{path} — Modify permissions, owner, group, MIME type.
- : Body: { "owner": "...", "group": "...", "mode": "rwxr-x---", "mime": "..." }
+ : Body: { "owner": …, "group": …, "mode": "rwxr-x---", "mime": … }
+ : db-core classifies failures: chown/chgrp/chmod -> 403, set-mime -> 400.
  :)
 declare function db:patch($request as map(*)) {
-    let $path := db:encode-path("/" || $request?parameters?path)
-    let $body := $request?body
-    return
-        try {
-            if (exists($body?owner)) then sm:chown($path, $body?owner) else (),
-            if (exists($body?group)) then sm:chgrp($path, $body?group) else (),
-            if (exists($body?mode)) then sm:chmod($path, $body?mode) else (),
-            if (exists($body?mime)) then xmldb:set-mime-type($path, $body?mime) else (),
-            map { "status": "ok" }
-        } catch * {
-            roaster:response(403, "application/json",
-                map { "error": $err:description })
-        }
-};
-
-
-(:~
- : Encode each segment of a path for eXist-db internal use.
- : Converts /db/AéB → /db/A%C3%A9B while preserving path separators.
- :)
-declare %private function db:encode-path($path as xs:string) as xs:string {
-    string-join(
-        for $segment in tokenize($path, "/")
-        return
-            if ($segment = "") then ""
-            else xmldb:encode($segment),
-        "/"
-    )
+    try {
+        let $body := $request?body
+        let $_ := dbc:set-permissions(map {
+            "path": db:wire($request),
+            "owner": $body?owner,
+            "group": $body?group,
+            "mode": $body?mode,
+            "mime": $body?mime
+        })
+        return map { "status": "ok" }
+    } catch * {
+        db:error-response($err:code, $err:description, $err:value)
+    }
 };
 
 (: ── Internal helpers ─────────────────────────────────────── :)
 
-declare %private function db:browse-collection($path, $request, $user) {
-    let $start := ($request?parameters?start, 1)[1]
-    let $count := ($request?parameters?count, 50)[1]
-    let $filter := $request?parameters?filter
-    let $children := xmldb:get-child-collections($path)
-    let $resources := xmldb:get-child-resources($path)
-    let $all-items := (
-        for $child in $children
-        where empty($filter) or contains($child, $filter)
-        order by lower-case($child)
-        return
-            let $child-path := $path || "/" || $child
-            let $child-uri := xs:anyURI($child-path)
-            return map {
-                "name": xmldb:decode-uri(xs:anyURI($child)),
-                "isCollection": true(),
-                "path": xmldb:decode-uri(xs:anyURI($child-path)),
-                "writable": sm:has-access($child-uri, "w"),
-                "permissions": sm:get-permissions($child-uri)/sm:permission/string(@mode),
-                "owner": sm:get-permissions($child-uri)/sm:permission/string(@owner),
-                "group": sm:get-permissions($child-uri)/sm:permission/string(@group)
-            },
-        for $res in $resources
-        where empty($filter) or contains($res, $filter)
-        order by lower-case($res)
-        return
-            let $res-path := $path || "/" || $res
-            let $res-uri := xs:anyURI($res-path)
-            return map {
-                "name": xmldb:decode-uri(xs:anyURI($res)),
-                "isCollection": false(),
-                "path": xmldb:decode-uri(xs:anyURI($res-path)),
-                "mime": xmldb:get-mime-type($res-path),
-                "writable": sm:has-access($res-uri, "w"),
-                "lastModified": string(xmldb:last-modified($path, $res)),
-                "permissions": sm:get-permissions($res-uri)/sm:permission/string(@mode),
-                "owner": sm:get-permissions($res-uri)/sm:permission/string(@owner),
-                "group": sm:get-permissions($res-uri)/sm:permission/string(@group)
-            }
-    )
-    let $total := count($all-items)
-    let $path-uri := xs:anyURI($path)
+(:~
+ : Browse a collection: db-core:list -> eXide's browse envelope/items shape.
+ : db-core does the pagination (start/count) and per-item writable; the adapter
+ : remaps key names (mode->permissions, children->items, type->isCollection,
+ : modified->lastModified, mime-type->mime). eXide's default page size is 50.
+ :)
+declare %private function db:browse($wire as xs:string, $request as map(*)) as map(*) {
+    let $r := dbc:list($wire, map {
+        "recursive": false(),
+        "depth": 0,
+        "collections-only": false(),
+        "start": ($request?parameters?start, 1)[1],
+        "count": ($request?parameters?count, 50)[1]
+    })
     return map {
-        "path": $path,
-        "total": $total,
-        "start": $start,
-        "count": $count,
-        "writable": sm:has-access($path-uri, "w"),
-        "permissions": sm:get-permissions($path-uri)/sm:permission/string(@mode),
-        "owner": sm:get-permissions($path-uri)/sm:permission/string(@owner),
-        "group": sm:get-permissions($path-uri)/sm:permission/string(@group),
-        "items": array { subsequence($all-items, $start, $count) }
+        "path": $r?path,
+        "total": $r?total,
+        "start": $r?start,
+        "count": $r?count,
+        "writable": $r?writable,
+        "permissions": $r?mode,
+        "owner": $r?owner,
+        "group": $r?group,
+        "items": array { for $c in $r?children?* return db:to-exide-item($c) }
     }
 };
 
-declare %private function db:get-run-path($path) {
+declare %private function db:to-exide-item($c as map(*)) as map(*) {
+    let $base := map {
+        "name": $c?name,
+        "isCollection": $c?type eq "collection",
+        "path": $c?path,
+        "writable": $c?writable,
+        "permissions": $c?mode,
+        "owner": $c?owner,
+        "group": $c?group
+    }
+    return
+        if ($c?type eq "collection")
+        then $base
+        else map:merge(($base, map {
+            "mime": $c?("mime-type"),
+            "lastModified": $c?modified
+        }))
+};
+
+(:~
+ : Load a document. XML (non-download) delegates to db-core:get-resource —
+ : including serialization (method/indent/omit-xml-declaration via #48, folded
+ : into db-core) and metadata (meta=full). Binary load and ?download raw
+ : streaming stay eXide-side until existdb-openapi#38's Roaster transport lands.
+ : externalPath is computed eXide's way (context-path aware), overriding
+ : db-core's runPath.
+ :
+ : eXide's serialization param names are translated to db-core's: omit-xml-decl
+ : -> omit-xml-declaration. expand-xincludes is intentionally not forwarded — it
+ : cannot be honored for node-to-string serialization in eXist 7.0.0-beta3
+ : (eXist-db/exist#3446); db-core omits it rather than give a false guarantee.
+ :)
+declare %private function db:load($wire as xs:string, $stored as xs:string, $request as map(*)) {
+    let $download := ($request?parameters?download, false())[1]
+    let $mime := xmldb:get-mime-type(xs:anyURI($stored))
+    return
+        if (not(sm:has-access(xs:anyURI($stored), "r"))) then
+            roaster:response(404, "application/json",
+                map { "error": "Not found or no read access" })
+        else if ($download) then
+            (: raw streaming — binary bytes as-is; XML via db-core's serializer :)
+            if (util:binary-doc-available($stored)) then
+                roaster:response(200, $mime, util:binary-doc($stored))
+            else
+                let $r := dbc:get-resource($wire, db:ser-opts($request))
+                return roaster:response(200, $mime, $r?content)
+        else if (util:binary-doc-available($stored)) then
+            db:load-binary($stored, $mime)
+        else
+            let $r := dbc:get-resource($wire,
+                map:merge((db:ser-opts($request), map { "meta": "full" })))
+            return map {
+                "path": $r?path,
+                "mime": $r?("mime-type"),
+                "binary": false(),
+                "externalPath": db:get-run-path($stored),
+                "content": $r?content,
+                "lastModified": $r?("last-modified"),
+                "permissions": $r?mode,
+                "owner": $r?owner,
+                "group": $r?group
+            }
+};
+
+(:~ db-core serialization options translated from eXide's request parameters. :)
+declare %private function db:ser-opts($request as map(*)) as map(*) {
+    map:merge((
+        if (exists($request?parameters?indent))
+            then map { "indent": $request?parameters?indent } else (),
+        if (exists($request?parameters?("omit-xml-decl")))
+            then map { "omit-xml-declaration": $request?parameters?("omit-xml-decl") } else ()
+    ))
+};
+
+(:~
+ : Binary load (non-download): include decoded content only for text-based binary
+ : types (matching eXide's editor behavior); never base64-decode true binaries.
+ : Stays eXide-side until db-core gains real binary transport (#38).
+ :)
+declare %private function db:load-binary($stored as xs:string, $mime as xs:string) as map(*) {
+    let $uri := xs:anyURI($stored)
+    let $collection := replace($stored, "/[^/]+$", "")
+    let $resource := replace($stored, "^.*/", "")
+    let $is-text := matches($mime, "^(text/|application/(xquery|javascript|json|xml|xslt\+xml|xsl-fo|css|less))")
+    let $content :=
+        if ($is-text)
+        then try { util:binary-to-string(util:binary-doc($stored)) } catch * { () }
+        else ()
+    return map:merge((
+        map {
+            "path": dbc:to-display($stored),
+            "mime": $mime,
+            "binary": true(),
+            "externalPath": db:get-run-path($stored),
+            "size": xmldb:size($collection, $resource),
+            "lastModified": string(xmldb:last-modified($collection, $resource)),
+            "permissions": sm:get-permissions($uri)/sm:permission/string(@mode),
+            "owner": sm:get-permissions($uri)/sm:permission/string(@owner),
+            "group": sm:get-permissions($uri)/sm:permission/string(@group)
+        },
+        if ($content) then map { "content": $content } else ()
+    ))
+};
+
+(:~
+ : Run path (URL to execute a stored resource) — eXide's context-path-aware
+ : computation, kept rather than db-core's hardcoded /exist form.
+ :)
+declare %private function db:get-run-path($path as xs:string) as xs:string {
     let $appRoot := repo:get-root()
     return
         replace(
@@ -277,70 +317,4 @@ declare %private function db:get-run-path($path) {
                 request:get-context-path() || "/rest" || $path,
             "/{2,}", "/"
         )
-};
-
-declare %private function db:load-document($path, $request, $user) {
-    let $download := ($request?parameters?download, false())[1]
-    let $indent := ($request?parameters?indent, "true")[1] = "true"
-    let $expand-xincludes := ($request?parameters?("expand-xincludes"), "false")[1] = "true"
-    let $omit-xml-decl := ($request?parameters?("omit-xml-decl"), "true")[1] = "true"
-    let $mime := xmldb:get-mime-type($path)
-    let $externalPath := db:get-run-path($path)
-    return
-        if (not(sm:has-access(xs:anyURI($path), "r"))) then
-            roaster:response(404, "application/json",
-                map { "error": "Not found or no read access" })
-        else if (util:binary-doc-available($path)) then
-            if ($download) then
-                roaster:response(200, $mime, util:binary-doc($path))
-            else
-                let $uri := xs:anyURI($path)
-                (: Text-based binary types: include content for editor :)
-                let $is-text := matches($mime, "^(text/|application/(xquery|javascript|json|xml|xslt\+xml|xsl-fo|css|less))")
-                let $content :=
-                    if ($is-text) then
-                        try { util:binary-to-string(util:binary-doc($path)) }
-                        catch * { () }
-                    else ()
-                return map:merge((
-                    map {
-                        "path": $path,
-                        "mime": $mime,
-                        "binary": true(),
-                        "externalPath": $externalPath,
-                        "size": xmldb:size(replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")),
-                        "lastModified": string(xmldb:last-modified(
-                            replace($path, "/[^/]+$", ""), replace($path, "^.*/", ""))),
-                        "permissions": sm:get-permissions($uri)/sm:permission/string(@mode),
-                        "owner": sm:get-permissions($uri)/sm:permission/string(@owner),
-                        "group": sm:get-permissions($uri)/sm:permission/string(@group)
-                    },
-                    if ($content) then map { "content": $content } else ()
-                ))
-        else
-            let $serialization-opts :=
-                "expand-xincludes=" || (if ($expand-xincludes) then "yes" else "no")
-            let $_ := util:declare-option("exist:serialize", $serialization-opts)
-            let $content := serialize(doc($path), <output:serialization-parameters>
-                <output:method>xml</output:method>
-                <output:indent>{if ($indent) then "yes" else "no"}</output:indent>
-                <output:omit-xml-declaration>{if ($omit-xml-decl) then "yes" else "no"}</output:omit-xml-declaration>
-            </output:serialization-parameters>)
-            return
-                if ($download) then
-                    roaster:response(200, $mime, $content)
-                else
-                    let $uri := xs:anyURI($path)
-                    return map {
-                        "path": $path,
-                        "mime": $mime,
-                        "binary": false(),
-                        "externalPath": $externalPath,
-                        "content": $content,
-                        "lastModified": string(xmldb:last-modified(
-                            replace($path, "/[^/]+$", ""), replace($path, "^.*/", ""))),
-                        "permissions": sm:get-permissions($uri)/sm:permission/string(@mode),
-                        "owner": sm:get-permissions($uri)/sm:permission/string(@owner),
-                        "group": sm:get-permissions($uri)/sm:permission/string(@group)
-                    }
 };

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -33,6 +33,7 @@ import module namespace dbc="http://exist-db.org/api/db-core";
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace sm="http://exist-db.org/xquery/securitymanager";
+declare namespace response="http://exist-db.org/xquery/response";
 
 (:~
  : Map a typed db-core error to an eXide HTTP response. db-core signals failures
@@ -238,9 +239,14 @@ declare %private function db:load($wire as xs:string, $stored as xs:string, $req
             roaster:response(404, "application/json",
                 map { "error": "Not found or no read access" })
         else if ($download) then
-            (: raw streaming — binary bytes as-is; XML via db-core's serializer :)
+            (: Binary download: stream the raw bytes with response:stream-binary —
+               the same path roaster's own test app uses. roaster:response(…, bytes)
+               would run the value through the serializer and emit its base64 TEXT
+               (corrupting the file); response:stream-binary writes the bytes. XML
+               download serializes via db-core (a text string), so roaster:response
+               is correct there. :)
             if (util:binary-doc-available($stored)) then
-                roaster:response(200, $mime, util:binary-doc($stored))
+                util:binary-doc($stored) => response:stream-binary($mime, ())
             else
                 let $r := dbc:get-resource($wire, db:ser-opts($request))
                 return roaster:response(200, $mime, $r?content)


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Rewrites `modules/api/db.xqm` as a thin **adapter** over existdb-openapi's roaster-independent `db-core` module. All resource CRUD and naming correctness is delegated **in-process** to db-core (imported by namespace — no HTTP hop, no re-auth; db-core runs as the request user), making existdb-openapi the single audited implementation of db resource handling. eXide stops carrying its own `xmldb:store` / `doc()` / encode logic.

The `/api/storage` surface and eXide's response shapes are **unchanged**, so the frontend is untouched.

## Status — draft, held per the migration plan

This is intentionally a **draft**:

- It imports `http://exist-db.org/api/db-core`, a public module that does not yet exist on openapi's `develop`. It is introduced by the db-core consolidation stack, still under review: existdb-openapi#55 (extracts db-core and registers it as a public XQuery module) and existdb-openapi#59 (the consolidated, binary-safe `get-resource` shape this adapter consumes — `{ path, binary, content, mime-type }`, no `meta=full`, no `runPath`). Against the published openapi the import does not resolve, so **CI is red until #55 and #59 land** on openapi `develop` and eXide's openapi dependency floor is bumped to that release.
- The **cutover is held**: adopting this adapter is also the resource-naming convention flip (eXide's full-encode `it%27s.xml` → db-core's `fn:iri-to-uri` form `it's.xml`), gated on the resource-naming contract decision (eXist-db/existdb-openapi#54).

**Before un-drafting:** (1) eXist-db/existdb-openapi#55 and eXist-db/existdb-openapi#59 merged; (2) bump the `http://exist-db.org/pkg/openapi` dependency `semver-min` in `expath-pkg.xml` to the db-core-registering release; (3) resource-naming convention decision (eXist-db/existdb-openapi#54).

## What changed

- **GET browse** → `dbc:list`, remapped to eXide's envelope/items (`mode`→`permissions`, `children`→`items`, `type`→`isCollection`, `modified`→`lastModified`, `mime-type`→`mime`); db-core does pagination and per-item `writable`.
- **GET load (XML, non-download)** → `dbc:get-resource` for serialized content (serialization params translated, `omit-xml-decl`→`omit-xml-declaration`) plus `dbc:properties` for `owner`/`group`/`mode`/`last-modified`. The consolidated db-core's `get-resource` returns just `{ path, binary, content, mime-type }` (no `meta=full`, no `runPath`), so metadata comes from `dbc:properties` and `externalPath` is computed eXide's context-path-aware way.
- **Binary load + `?download` raw streaming** stay eXide-side until db-core gains real binary transport (existdb-openapi#38), streamed via `response:stream-binary` to avoid double-escaping.
- **PUT / POST (create\|copy\|move\|rename) / DELETE / PATCH** → the matching db-core calls, remapped to `{ status: "ok"[, path] }`. DELETE passes `force=true` (eXide's recursive semantics); db-core's protected-path guard (403) and copy/move overwrite guard (409) now apply. PATCH errors are classified by db-core (chmod/chown/chgrp → 403, set-mime → 400).
- Drops the dead `config:` / `dbutil:` imports and the unused `filter` query param (declared and handled but never sent by the frontend).

## Testing

Adds `cypress/e2e/db_resource_adapter_spec.cy.js` (9 tests) guarding the adapter paths the broader suite leaves unasserted: the metadata re-sourced from `dbc:properties` (both the `db:load` envelope and the properties dialog that consumes it), serialization params driven through a load, `?download` for XML and binary, `db:patch` Apply, and resource-level delete.

These were **mutation-verified**: reverting `db:load` to read metadata from `get-resource` (the regression the consolidated contract would introduce if mishandled) fails the envelope/properties/patch assertions while serialization/download/store/delete stay green — so the guard demonstrably guards.

Verified on a disposable eXist bed running the consolidated `existdb-openapi` (0.9.7, from existdb-openapi#59) + roaster 1.12.0 + this build: the 9 new tests plus the genuinely adapter-relevant existing specs (`file_save`, `dbmanager`, `binary_preview`) are green (44/44), and the JS unit suite is 179/179.
