### PR TITLE
test(cypress): run test cleanup via /eXide/execute, not raw XQuery over /exist/rest

### DIFF
--- a/cypress/e2e/dbmanager_spec.cy.js
+++ b/cypress/e2e/dbmanager_spec.cy.js
@@ -7,15 +7,10 @@ function openDbManager() {
 
 function cleanupTestCollections() {
   cy.loginXHR('admin', '')
-  cy.request({
-    method: 'POST',
-    url: '/exist/rest/db',
-    headers: { 'Content-Type': 'application/xquery' },
-    body: `for $col in ("${collectionName}", "def", "AéB")
-           where xmldb:collection-available("/db/" || $col)
-           return xmldb:remove("/db/" || $col)`,
-    failOnStatusCode: false
-  })
+  cy.execXQuery(`xquery version "3.1";
+    for $col in ("${collectionName}", "def", "AéB")
+    where xmldb:collection-available("/db/" || $col)
+    return xmldb:remove("/db/" || $col)`)
 }
 
 context('DB Manager', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,16 +51,24 @@ Cypress.Commands.add("dismissDialog", () => {
     })
 })
 
+// cy.execXQuery() -- run a setup/cleanup XQuery as the logged-in user, via eXide's
+// execute endpoint. NOTE: posting raw XQuery to /exist/rest as application/xquery does
+// NOT execute it -- eXist parses the body as XML and 400s ("Content is not allowed in
+// prolog"), so any such cleanup masked with failOnStatusCode:false silently no-ops.
+// /eXide/execute is the suite's proven path for running setup queries.
+Cypress.Commands.add("execXQuery", (query) => {
+    return cy.request({
+        method: 'POST',
+        url: '/eXide/execute',
+        form: true,
+        body: { qu: query, base: 'xmldb:exist://__new__1', output: 'adaptive' }
+    })
+})
+
 // cy.cleanupTestFiles() -- removes cypress-test-* files from /db
 Cypress.Commands.add("cleanupTestFiles", () => {
     cy.loginXHR('admin', '')
-    cy.request({
-        method: 'POST',
-        url: '/exist/rest/db',
-        headers: { 'Content-Type': 'application/xquery' },
-        body: 'for $r in xmldb:get-child-resources("/db") where starts-with($r, "cypress-test-") return xmldb:remove("/db", $r)',
-        failOnStatusCode: false
-    })
+    cy.execXQuery('xquery version "3.1"; for $r in xmldb:get-child-resources("/db") where starts-with($r, "cypress-test-") return xmldb:remove("/db", $r)')
 })
 
 // cy.logout() -- does not work reliably


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

The Cypress suite's two test-cleanup helpers never actually delete anything. Both POST raw XQuery to `/exist/rest` with `Content-Type: application/xquery`, which eXist does not execute — it parses the body as XML and returns **400 "SAX exception while parsing request: Content is not allowed in prolog."** Because both calls are wrapped in `failOnStatusCode: false`, the failure is swallowed and the cleanup **silently no-ops**:

- `cy.cleanupTestFiles()` (`cypress/support/commands.js`) — used by the global `beforeEach` safety-net in `cypress/support/e2e.js` and by `file_save_spec`, `run_as_test_dirty_spec`, and `run_as_test_results_spec`.
- `cleanupTestCollections()` (`cypress/e2e/dbmanager_spec.cy.js`) — `before`/`after` hooks.

So `/db/cypress-test-*` files and the dbmanager test collections (`abc`, `def`, `AéB`, …) accumulate across runs. The `e2e.js` comment ("cypress creates multiple copies of /db/cypress-test-[digits].xq") is describing the symptom of cleanup never running.

## Fix

Add a `cy.execXQuery(query)` command that runs setup/cleanup XQuery via **`/eXide/execute`** — the same endpoint `dbmanager_spec`'s "create resource using xmldb" test already uses successfully — and route both cleanups through it. The `failOnStatusCode: false` mask is removed so a future cleanup break fails loudly instead of silently.

The new command carries a comment documenting why the old `/exist/rest` + `application/xquery` approach didn't work, to keep the pattern from creeping back in.

## Verification

On a local eXist bed running this branch's build:

- **Before (current `develop`):** the cleanup POST returns 400 and a seeded `/db/cypress-test-PROBE.xq` is still present afterward — confirmed no-op.
- **After (this branch):** the same cleanup via `/eXide/execute` returns 200 and removes the file.
- The affected specs (`dbmanager_spec`, `file_save_spec`, `run_as_test_dirty_spec`, `run_as_test_results_spec`) pass — 39/39.
- After the run, `/db` is left **clean** of `cypress-test-*` files and the dbmanager test collections (previously they accumulated unbounded).

This is a test-only change, independent of any in-flight work.
