### PR TITLE
fix(query): surface query errors returned in a 200 body

### DIFF
--- a/cypress/e2e/query_error_display_spec.cy.js
+++ b/cypress/e2e/query_error_display_spec.cy.js
@@ -90,7 +90,7 @@ describe('Query error display', () => {
       )
     })
 
-    cy.get('#exide-err-panel-dismiss').click()
+    clearError()
   })
 
   it('syntax error — shows real cause, not "Unknown error"', () => {
@@ -108,6 +108,23 @@ describe('Query error display', () => {
       )
     })
 
-    cy.get('#exide-err-panel-dismiss').click()
+    clearError()
+  })
+
+  it('static arity error (XPST0017) — surfaced even when reported in a 200 body', () => {
+    // Reproduction from eXist-db/eXide#828: concat() with one argument. Older
+    // existdb-openapi returns this compile error as HTTP 200 { error: ... }
+    // instead of an error status; the run path must still surface it.
+    setEditorContent('concat("test")')
+    runAndCaptureError().should((text) => {
+      expect(text).not.to.contain('Unknown error')
+      expect(text).to.satisfy((t) =>
+        /XPST0017/.test(t) ||
+        /at least two arguments/i.test(t) ||
+        /concat/i.test(t)
+      )
+    })
+
+    clearError()
   })
 })

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -970,6 +970,21 @@ eXide.app = (function(util) {
 		            });
 		        }
 		        return response.json().then(function(data) {
+		            // Defend against a query error reported in a 200 body rather
+		            // than an error status — e.g. existdb-openapi before
+		            // eXist-db/existdb-openapi#46 returned a compile error as
+		            // HTTP 200 { error: ... } (eXist-db/eXide#828). Without this the
+		            // error is swallowed: data.cursor/items are undefined and the
+		            // success path shows neither results nor an error. Coalesce the
+		            // shapes the same way the !response.ok branch does.
+		            if (data.error || !data.cursor) {
+		                var emsg = data.description || data.error || data.message
+		                    || "Query failed: no cursor returned.";
+		                if (data.code) { emsg = "[" + data.code + "] " + emsg; }
+		                if (data.line > 0) { emsg = "line " + data.line + ": " + emsg; }
+		                editor.evalError(emsg, !livePreview, data);
+		                return;
+		            }
 		            app._cursorId = data.cursor;
 		            hitCount = data.items;
 		            endOffset = Math.min(numberOfResults, hitCount);


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Fixes #828: running a query whose error existdb-openapi reports in a `200` body — e.g. `concat("test")` (XPST0017) — produced no result and no error; the exception was silently swallowed.

## Root cause

`runQueryCursor` POSTs to existdb-openapi's `/api/query` and branches on `response.ok`: on a non-2xx it surfaces the error, on a 2xx it treats the body as a cursor result. But existdb-openapi **before eXist-db/existdb-openapi#46** returns a compile/eval error as **HTTP 200** with `{ "error": "Invalid context-item: …" }` instead of an error status. So the success branch ran with `data.cursor`/`data.items` undefined — neither results nor an error were shown.

`eXist-db/existdb-openapi#46` (merged to openapi `develop`) is the upstream root fix: it returns a proper error status, which eXide's existing `!response.ok` path already handles.

## Change

Defense-in-depth on the eXide side, so the error surfaces regardless of openapi version: if a `200` response carries an `error` (or has no `cursor`), `runQueryCursor` routes it through `editor.evalError`, coalescing the error shape exactly as the `!response.ok` branch does (`description`/`error`/`message`, plus `code` and `line`). Success responses are `{ cursor, items, elapsed, timing }` and never carry `error`, so the guard is safe.

## Tests

`query_error_display_spec` gains a case for the static-arity error (XPST0017) reported in a 200 body. The cleanups now use the existing `clearError()` helper rather than clicking the panel dismiss button (robust — the error panel auto-opens only on pill-click, so the button isn't visible after a `Run`). The previously-flaky type-error case (`1 + "a"`, XPTY0004), swallowed for the same reason, now passes reliably.

Verified on a Roaster + existdb-openapi 0.9.7 (pre-#46) instance: `concat("test")` and `1 + "a"` both surface their real cause; valid queries still run and page normally.
