### PR TITLE
fix(deployment): stop poisoning eXide.projects localStorage that crashes eXide 3.x

### DIFF
--- a/src/deployment.js
+++ b/src/deployment.js
@@ -20,6 +20,36 @@ eXide.namespace("eXide.edit.Projects");
 
 eXide.edit.Projects = (function () {
 
+    // localStorage["eXide.projects"] is shared between eXide versions running
+    // against the same browser. eXide 3.x stores it as a flat map of
+    // abbrev -> project object, and its getProjectFor() reads
+    // `project.root.length` for EVERY entry with no guard (eXide <= 3.5.x,
+    // src/deployment.js). So any value lacking a string `root` crashes 3.x
+    // hard on load with "Cannot read properties of undefined (reading
+    // 'length')". To stay compatible when a user alternates between 3.x and
+    // 4.x against the same storage, every entry we keep — and everything we
+    // persist — must be a real project with a string `root`. In particular we
+    // must never write the malformed `{ "undefined": { packages: [...] } }`
+    // entry that a non-app `api/packages` response would otherwise produce.
+    function isProject(value) {
+        return value != null && typeof value === "object" &&
+            typeof value.root === "string" && value.root.length > 0;
+    }
+
+    // Keep only well-formed project entries (and drop the "undefined" key),
+    // so a malformed entry can neither be persisted nor survive a reload.
+    function sanitizeProjects(projects) {
+        const clean = {};
+        if (projects && typeof projects === "object") {
+            Object.keys(projects).forEach(function (key) {
+                if (key !== "undefined" && isProject(projects[key])) {
+                    clean[key] = projects[key];
+                }
+            });
+        }
+        return clean;
+    }
+
     Constr = function () {
         this.projects = {};
     };
@@ -45,7 +75,11 @@ eXide.edit.Projects = (function () {
             if (!response.ok) return null;
             return response.json();
         }).then(function (data) {
-            if (!data) {
+            // A non-app collection yields a response without an abbrev/root
+            // (e.g. the full `{ packages: [...] }` list). Treat that as "no
+            // project" rather than storing it under the key "undefined", which
+            // would poison eXide.projects (see isProject above).
+            if (!isProject(data) || !data.abbrev) {
                 cb(null);
                 return;
             }
@@ -64,21 +98,23 @@ eXide.edit.Projects = (function () {
 
     Constr.prototype.getProjectFor = function (collection) {
         const filteredProjects = Object.values(this.projects)
-            .filter(project => project &&  project.root && collection.startsWith(project.root));
+            .filter(project => isProject(project) && collection.startsWith(project.root));
 
         return filteredProjects[0] || null;
     };
 
     Constr.prototype.saveState = function () {
-        localStorage["eXide.projects"] = JSON.stringify(this.projects);
+        // Sanitize on the way out so a malformed in-memory entry can never be
+        // persisted — this is what keeps a later eXide 3.x load from crashing.
+        localStorage["eXide.projects"] = JSON.stringify(sanitizeProjects(this.projects));
     };
 
     Constr.prototype.restoreState = function () {
         const $this = this;
         if (localStorage["eXide.projects"]) {
-            this.projects = JSON.parse(localStorage["eXide.projects"]);
-            if (typeof this.projects != 'object')
-                this.projects = {};
+            // Sanitize on the way in so storage already poisoned by an earlier
+            // build self-heals on the next load.
+            this.projects = sanitizeProjects(JSON.parse(localStorage["eXide.projects"]));
         }
         // refresh state to see if app package config has chaged in the db (e.g added Git)
         const projects = this.projects;
@@ -419,3 +455,10 @@ eXide.edit.PackageEditor = (function () {
 
     return Constr;
 }());
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        Projects: eXide.edit.Projects,
+        PackageEditor: eXide.edit.PackageEditor
+    };
+}

--- a/test/deployment-test.js
+++ b/test/deployment-test.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for eXide.edit.Projects localStorage handling.
+ *
+ * Regression coverage for eXist-db/eXide#835: eXide 4.0.1 persisted a
+ * malformed `{ "undefined": { packages: [...] } }` entry into
+ * localStorage["eXide.projects"], which crashes eXide 3.x on load
+ * (its getProjectFor reads `project.root.length` for every entry with
+ * no guard). These tests pin that such an entry is never created, never
+ * persisted, and is stripped from already-poisoned storage on load — so
+ * a user alternating between eXide 3.x and 4.x against the same browser
+ * storage is not broken.
+ */
+const { describe, it, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+
+// --- Minimal eXide browser-global shims so src/deployment.js loads in Node ---
+const eXide = {};
+eXide.namespace = function (ns) {
+    const parts = ns.split(".").filter(function (p) { return p !== "eXide"; });
+    let parent = eXide;
+    parts.forEach(function (p) {
+        if (typeof parent[p] === "undefined") { parent[p] = {}; }
+        parent = parent[p];
+    });
+    return parent;
+};
+eXide.namespace("eXide.util.oop");
+eXide.util.oop.inherit = function (C, P) {
+    const F = function () {};
+    F.prototype = P.prototype;
+    C.prototype = new F();
+    C.super_ = P.prototype;
+    C.prototype.constructor = C;
+};
+eXide.namespace("eXide.events");
+eXide.events.Sender = function () {};               // parent class referenced at load time
+eXide.util.DialogManager = { create: function () { return {}; } };
+eXide.app = { getPreference: function () { return false; } };
+global.eXide = eXide;
+global.document = { getElementById: function () { return null; } };
+
+const { Projects } = require(path.join(__dirname, "..", "src", "deployment.js"));
+
+// eXist-db/eXide#835: the exact entry eXide 4.0.1 used to persist.
+const POISON = { packages: [{ abbrev: "dashboard", path: "/db/apps/dashboard" }] };
+const APP = { root: "/db/apps/my-app", abbrev: "my-app", title: "My App" };
+
+beforeEach(function () {
+    global.localStorage = {};
+    global.fetch = function () { return Promise.resolve({ ok: false }); };
+});
+
+describe("eXide.edit.Projects — localStorage poisoning (#835)", function () {
+
+    it("getProjectFor tolerates a malformed entry and still resolves the real project", function () {
+        const p = new Projects();
+        p.projects = { "my-app": APP, "undefined": POISON };
+        assert.doesNotThrow(function () {
+            assert.equal(p.getProjectFor("/db/apps/my-app/data.xml").abbrev, "my-app");
+            assert.equal(p.getProjectFor("/db/other/thing.xml"), null);
+        });
+    });
+
+    it("saveState never persists a malformed entry", function () {
+        const p = new Projects();
+        p.projects = { "my-app": APP, "undefined": POISON };
+        p.saveState();
+        const saved = JSON.parse(global.localStorage["eXide.projects"]);
+        assert.deepEqual(Object.keys(saved), ["my-app"]);
+        assert.ok(!("undefined" in saved), "the 'undefined' key must not be persisted");
+    });
+
+    it("restoreState heals storage already poisoned by an earlier build", function () {
+        global.localStorage["eXide.projects"] = JSON.stringify({
+            "my-app": APP,
+            "undefined": POISON
+        });
+        const p = new Projects();
+        p.restoreState();
+        assert.deepEqual(Object.keys(p.projects), ["my-app"]);
+    });
+
+    it("getProject does not store an abbrev-less (package-list) response as 'undefined'", async function () {
+        const p = new Projects();
+        global.fetch = function () {
+            return Promise.resolve({ ok: true, json: function () { return Promise.resolve(POISON); } });
+        };
+        const result = await new Promise(function (resolve) {
+            p.getProject("/db/apps/not-an-app", resolve);
+        });
+        assert.equal(result, null);
+        assert.deepEqual(p.projects, {}, "no 'undefined' key may be created");
+    });
+
+    it("getProject still stores a well-formed project response", async function () {
+        const p = new Projects();
+        global.fetch = function () {
+            return Promise.resolve({ ok: true, json: function () { return Promise.resolve(APP); } });
+        };
+        const result = await new Promise(function (resolve) {
+            p.getProject("/db/apps/my-app", resolve);
+        });
+        assert.equal(result.abbrev, "my-app");
+        assert.deepEqual(Object.keys(p.projects), ["my-app"]);
+    });
+
+    it("eXide 3.x can read 4.x's persisted state without crashing (cross-version)", function () {
+        // Exact getProjectFor from eXide 3.5.4 (src/deployment.js) — no guard,
+        // reads project.root.length for every entry. Reproduces the #835 crash.
+        function getProjectFor_3x(projects, collection) {
+            for (const k in projects) {
+                const project = projects[k];
+                if (collection.substring(0, project.root.length) === project.root) {
+                    return project;
+                }
+            }
+            return null;
+        }
+
+        // 4.x has the poison entry in memory and saves...
+        const p = new Projects();
+        p.projects = { "my-app": APP, "undefined": POISON };
+        p.saveState();
+        const asSeenBy3x = JSON.parse(global.localStorage["eXide.projects"]);
+
+        // ...and 3.x reads what 4.x wrote. Opening a document NOT under any
+        // app forces getProjectFor to iterate every entry: with the old
+        // saveState the persisted poison entry made it throw "Cannot read
+        // properties of undefined (reading 'length')" — exactly the #835 crash.
+        assert.doesNotThrow(function () {
+            assert.equal(getProjectFor_3x(asSeenBy3x, "/db/other/note.xml"), null);
+        });
+        // and a document under the real app still resolves
+        assert.equal(getProjectFor_3x(asSeenBy3x, "/db/apps/my-app/x.xml").abbrev, "my-app");
+    });
+});


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

eXide 4.x persisted a malformed entry into `localStorage["eXide.projects"]` that crashes eXide 3.x on load. This stops that entry from ever being written, heals storage already poisoned by an earlier build, and documents the cross-version shape contract.

## The bug

Whenever `getProject()` ran for a collection that isn't an installed app, the `api/packages/?collection=` request returned an abbrev-less package-list response, which was then stored under the key `data.abbrev` — i.e. the string `"undefined"` — with a shape (`{ packages: [...] }`) that isn't a project:

```jsonc
"eXide.projects": {
  "my-app": { "root": "/db/apps/my-app", "abbrev": "my-app", ... },
  "undefined": { "packages": [ ... ] }   // ← poison
}
```

eXide 4.x tolerates that entry (its `getProjectFor` filters on `project.root`), but eXide 3.x does not — its `getProjectFor` reads `project.root.length` for every entry with no guard, so loading the shared storage throws:

```
deployment.js:62 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at Constr.getProjectFor (deployment.js:62:54)
```

A user who alternates between eXide 3.x and 4.x against the same browser (reported in #835: eXist 6.4.1 ↔ 7.0.0 containers) had to clear localStorage by hand to recover.

## The fix

`localStorage["eXide.projects"]` is a flat map of `abbrev → project` that every eXide version sharing the browser reads, so it is a **cross-version contract**: every entry must be a real project with a string `root`. This change:

- **guards `getProject()`** so an abbrev-less / root-less response is treated as "no project" instead of being stored under `"undefined"`;
- **sanitizes on `saveState`** (a malformed in-memory entry is never persisted — this is what protects a later 3.x load) and **on `restoreState`** (storage already poisoned by an earlier build self-heals on the next load);
- **documents the shape contract** in the source so it isn't reintroduced.

No change to the project shape itself — 4.x's richer project objects already carry `root` and remain readable by 3.x.

## Tests

Adds `test/deployment-test.js` (6 tests, `node --test`): `getProjectFor` tolerates a malformed entry; `saveState`/`restoreState` strip it; `getProject` won't create `"undefined"`; valid projects still store. The last test runs **eXide 3.5.4's exact unguarded `getProjectFor`** against the state 4.x persists and asserts it no longer throws.

Each fix site is mutation-verified (reverting it fails the corresponding test). Full suite: 185 pass.

## Scope

This stops the corruption and the crash. The underlying reason `getProject` received an abbrev-less response — `api/packages/?collection=` routing to the package-list handler instead of the by-collection resolver — is a separate issue addressed in a follow-up PR (the discovery came out of investigating this one); it is not required to fix #835.

Reported by @DrRataplan.

Fixes #835.
