### PR TITLE
fix(packages): resolve /api/packages?collection= and report the app's real root

### DIFF
--- a/cypress/e2e/packages_by_collection_spec.cy.js
+++ b/cypress/e2e/packages_by_collection_spec.cy.js
@@ -48,4 +48,26 @@ context('GET /api/packages?collection=', () => {
       expect(r.body).to.not.have.property('packages')
     })
   })
+
+  it('reports a matching root so getProjectFor can match an open document', () => {
+    // root must be a prefix of where the app's documents live; getProjectFor
+    // matches doc.getBasePath().startsWith(project.root). It was "/db/<target>"
+    // (e.g. "/db/eXide"), which is not where files are, so nothing matched.
+    cy.request('/eXide/api/packages?collection=/db/apps/eXide/modules').then((r) => {
+      expect(r.body.root).to.eq('/db/apps/eXide')
+      expect('/db/apps/eXide/modules'.startsWith(r.body.root)).to.be.true
+    })
+  })
+})
+
+// End-to-end: opening a document inside an app lights up the toolbar's
+// current-app indicator. This exercises the whole chain — the by-collection
+// route, the corrected `root`, and getProjectFor — through the real UI.
+describe('Current-app detection in the toolbar', () => {
+  it('shows the owning app when a document inside an app is opened', () => {
+    cy.loginXHR('admin', '')
+    cy.visit('/eXide/index.html?open=/db/apps/eXide/expath-pkg.xml')
+    cy.get('#user', { timeout: 15000 }).should('not.have.text', 'Login')
+    cy.get('#toolbar-current-app', { timeout: 15000 }).should('have.text', 'eXide')
+  })
 })

--- a/cypress/e2e/packages_by_collection_spec.cy.js
+++ b/cypress/e2e/packages_by_collection_spec.cy.js
@@ -1,0 +1,51 @@
+// Guards the by-collection package lookup: GET /api/packages?collection=<path>.
+//
+// Discovered while investigating eXist-db/eXide#835: the editor's
+// `api/packages/?collection=` request (used to discover which app an open
+// document belongs to) was routing to the bare /api/packages list handler,
+// which ignored ?collection= and returned the full {packages:[...]} list.
+// That abbrev-less list was then mis-stored, which is what poisoned
+// localStorage in #835. These tests pin that ?collection= now resolves the
+// single owning package (or 404), and that the no-arg call still lists.
+
+context('GET /api/packages?collection=', () => {
+  beforeEach(() => {
+    cy.loginXHR('admin', '')
+  })
+
+  it('resolves the single package that owns a collection', () => {
+    cy.request('/eXide/api/packages?collection=/db/apps/eXide').then((r) => {
+      expect(r.status).to.eq(200)
+      expect(r.body).to.have.property('abbrev', 'eXide')
+      // a single descriptor, NOT the full list shape
+      expect(r.body).to.not.have.property('packages')
+    })
+  })
+
+  it('resolves the owning package from a sub-collection path', () => {
+    cy.request('/eXide/api/packages?collection=/db/apps/eXide/modules').then((r) => {
+      expect(r.status).to.eq(200)
+      expect(r.body).to.have.property('abbrev', 'eXide')
+    })
+  })
+
+  it('still returns the full list when no collection is given', () => {
+    cy.request('/eXide/api/packages').then((r) => {
+      expect(r.status).to.eq(200)
+      expect(r.body).to.have.property('packages')
+      expect(r.body.packages).to.be.an('array')
+      expect(r.body.packages.length).to.be.greaterThan(0)
+    })
+  })
+
+  it('returns 404 for a collection not inside any app (no abbrev-less list to poison localStorage)', () => {
+    cy.request({
+      url: '/eXide/api/packages?collection=/db/not-an-app-' + Date.now(),
+      failOnStatusCode: false
+    }).then((r) => {
+      expect(r.status).to.eq(404)
+      expect(r.body).to.not.have.property('abbrev')
+      expect(r.body).to.not.have.property('packages')
+    })
+  })
+})

--- a/modules/api.json
+++ b/modules/api.json
@@ -1151,9 +1151,20 @@
                 "tags": [
                     "packages"
                 ],
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "query",
+                        "required": false,
+                        "description": "If given, return only the single package that owns this collection path (404 if none), instead of the full list.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Package list",
+                        "description": "Package list, or a single package descriptor when ?collection= is given",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/modules/api/packages.xqm
+++ b/modules/api/packages.xqm
@@ -119,8 +119,14 @@ declare function packages:get($request as map(*)) {
         if (exists($expath)) then
             let $user := sm:id()//sm:real/sm:username/string()
             let $is-admin := if ($user) then sm:is-dba($user) else false()
-            let $target-col := "/db/" || string($repo-meta/repo:target)
-            let $git-xml := doc($target-col || "/git.xml")
+            (: $col is the installed app collection (repo-root || abbrev), where
+               expath-pkg.xml was just resolved — i.e. where the app's documents
+               actually live. The editor's getProjectFor matches an open
+               document's collection against `root` with startsWith(), so `root`
+               must be this path. (It was "/db/" || repo:target, which drops the
+               repo root: e.g. "/db/eXide" instead of "/db/apps/eXide", a
+               collection that does not exist, so no document ever matched.) :)
+            let $git-xml := doc($col || "/git.xml")
             return map {
                 "abbrev": string($expath/@abbrev),
                 "name": string($expath/@name),
@@ -128,7 +134,7 @@ declare function packages:get($request as map(*)) {
                 "version": string($expath/@version),
                 "type": string(($repo-meta/repo:type, "application")[1]),
                 "target": string($repo-meta/repo:target),
-                "root": $target-col,
+                "root": $col,
                 "url": "/" || string($repo-meta/repo:target),
                 "deployed": string($repo-meta/repo:deployed),
                 "description": string($repo-meta/repo:description),

--- a/modules/api/packages.xqm
+++ b/modules/api/packages.xqm
@@ -41,8 +41,24 @@ declare variable $packages:ANT_FILE :=
 
 (:~
  : GET /api/packages — List installed packages.
+ :
+ : With ?collection=<path>, resolve and return the single package that owns
+ : that collection (the same descriptor as GET /api/packages/{abbrev}), or
+ : 404 if the path is not inside any installed app. This is the by-collection
+ : lookup the editor uses to discover which app an open document belongs to;
+ : without it a non-empty ?collection= was silently ignored and the full list
+ : returned instead (discovered while investigating eXist-db/eXide#835).
  :)
 declare function packages:list($request as map(*)) {
+    let $collection := $request?parameters?collection
+    return
+        if (exists($collection) and $collection != "") then
+            packages:get($request)
+        else
+            packages:list-all()
+};
+
+declare function packages:list-all() {
     let $root := repo:get-root()
     let $apps :=
         for $app in xmldb:get-child-collections($root)


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Restores eXide's "which app does this document belong to?" detection, which has been broken since the Roaster API rewrite. Two defects in the same chain are fixed: the by-collection lookup routed to the wrong handler, and the returned `root` pointed at a collection that doesn't exist. Discovered while investigating #835.

## Background

When you open a document, eXide resolves the app that owns it to drive the toolbar's current-app indicator, "Find in files" app scoping, and live-reload. The editor requests `api/packages/?collection=<path>` for this.

## Bug 1 — the lookup never reached the resolver

That URL has no `{abbrev}` path segment, so Roaster routed it to the bare `/api/packages` list handler, which **ignored `?collection=`** and returned the full `{ packages: [...] }` list. The intended resolver — `packages:get`, which maps a collection path to its single owning package — was never reached. (That abbrev-less list response is also what got mis-stored under the key `"undefined"`, the localStorage corruption fixed in #835.)

**Fix:** `packages:list` now delegates to `packages:get` when `?collection=` is present, returning the single package descriptor (or `404` when the path is not inside any installed app); the no-arg call still lists every package. The existing list body moves to `packages:list-all`, and `api.json` declares the optional `collection` query parameter. No client change is needed — the editor's existing request URL now reaches the resolver.

## Bug 2 — `root` pointed at a nonexistent collection

`packages:get` derived `root` as `"/db/" || repo:target` — e.g. `/db/eXide` — but apps live under the repository root, at `/db/apps/eXide`. The `/db/<target>` collection doesn't exist, so `getProjectFor` (which matches an open document's collection with `startsWith(project.root)`) never matched even once the resolver was reachable.

**Fix:** use `$col` (`repo-root || abbrev`) — the installed app collection where `expath-pkg.xml` was just resolved and where the app's documents actually live — for both `root` and the `git.xml` lookup. This also affects the existing `GET /api/packages/{abbrev}` endpoint, which had the same wrong `root`.

## Tests

Adds `cypress/e2e/packages_by_collection_spec.cy.js` (6 tests):

- `?collection=` resolves the single owning package (including from a sub-collection path) and returns a single descriptor, not the list shape;
- the no-arg call still returns the full list;
- a non-app collection returns `404` (no abbrev-less list to poison localStorage);
- `root` is the collection where documents live (`/db/apps/eXide`, a prefix of an open document's path);
- **end-to-end:** opening a document inside an app lights up the toolbar's current-app indicator — exercising the route, the corrected `root`, and `getProjectFor` through the real UI.

All 6 pass.

Refs #835.
