### PR TITLE
fix(db): tolerate an unreadable child in the storage listing; surface browse errors

### DIFF
--- a/cypress/e2e/storage_listing_resilience_spec.cy.js
+++ b/cypress/e2e/storage_listing_resilience_spec.cy.js
@@ -1,0 +1,40 @@
+// Guards the storage-listing resilience fix (same family as existdb-openapi#72,
+// #69): one child whose permissions a user can't read must not 500 the whole
+// listing — it degrades to accessible:false. As guest, /db/system/security is
+// rwxrwx--- (guest outside owner/group), so sm:get-permissions on it throws;
+// db:browse-collection must catch that per-child rather than failing the listing.
+
+context('Storage listing resilience — unreadable child does not 500', () => {
+  it('lists /db/system as guest with the locked child degraded, not fatal', () => {
+    cy.request({
+      url: '/eXide/api/storage/db/system',
+      auth: { username: 'guest', password: 'guest' }
+    }).then((r) => {
+      expect(r.status).to.eq(200)
+
+      const byName = {}
+      r.body.items.forEach((it) => { byName[it.name] = it })
+
+      // World-readable children stay visible and accessible.
+      expect(byName.config, 'config present').to.exist
+      expect(byName.config.accessible).to.eq(true)
+      expect(byName.repo, 'repo present').to.exist
+      expect(byName.repo.accessible).to.eq(true)
+
+      // The unreadable child is present but flagged — not an exception.
+      expect(byName.security, 'security present').to.exist
+      expect(byName.security.accessible).to.eq(false)
+    })
+  })
+
+  it('marks readable entries accessible:true', () => {
+    cy.loginXHR('admin', '')
+    cy.request('/eXide/api/storage/db').then((r) => {
+      expect(r.status).to.eq(200)
+      // admin can read everything under /db — every entry carries accessible:true
+      r.body.items.forEach((it) => {
+        expect(it.accessible, it.name + ' accessible').to.eq(true)
+      })
+    })
+  })
+})

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -209,6 +209,21 @@ declare %private function db:encode-path($path as xs:string) as xs:string {
 
 (: ── Internal helpers ─────────────────────────────────────── :)
 
+(: A degraded child entry for a collection/resource whose metadata can't be read
+   — typically guest hitting sm:get-permissions() on an unreadable sibling such as
+   /db/system/security (rwxrwx---). Carries the fields known without reading the
+   child's permissions, plus accessible=false and the error, so one locked child
+   can't 500 the whole listing. Mirrors existdb-openapi#72's inaccessible-entry. :)
+declare %private function db:inaccessible-entry($name, $is-collection, $path, $error) {
+    map {
+        "name": $name,
+        "isCollection": $is-collection,
+        "path": $path,
+        "accessible": false(),
+        "error": $error
+    }
+};
+
 declare %private function db:browse-collection($path, $request, $user) {
     let $start := ($request?parameters?start, 1)[1]
     let $count := ($request?parameters?count, 50)[1]
@@ -222,32 +237,48 @@ declare %private function db:browse-collection($path, $request, $user) {
         return
             let $child-path := $path || "/" || $child
             let $child-uri := xs:anyURI($child-path)
-            return map {
-                "name": xmldb:decode-uri(xs:anyURI($child)),
-                "isCollection": true(),
-                "path": xmldb:decode-uri(xs:anyURI($child-path)),
-                "writable": sm:has-access($child-uri, "w"),
-                "permissions": sm:get-permissions($child-uri)/sm:permission/string(@mode),
-                "owner": sm:get-permissions($child-uri)/sm:permission/string(@owner),
-                "group": sm:get-permissions($child-uri)/sm:permission/string(@group)
-            },
+            let $name := xmldb:decode-uri(xs:anyURI($child))
+            let $disp-path := xmldb:decode-uri(xs:anyURI($child-path))
+            return
+                try {
+                    map {
+                        "name": $name,
+                        "isCollection": true(),
+                        "path": $disp-path,
+                        "accessible": sm:has-access($child-uri, "r"),
+                        "writable": sm:has-access($child-uri, "w"),
+                        "permissions": sm:get-permissions($child-uri)/sm:permission/string(@mode),
+                        "owner": sm:get-permissions($child-uri)/sm:permission/string(@owner),
+                        "group": sm:get-permissions($child-uri)/sm:permission/string(@group)
+                    }
+                } catch * {
+                    db:inaccessible-entry($name, true(), $disp-path, $err:description)
+                },
         for $res in $resources
         where empty($filter) or contains($res, $filter)
         order by lower-case($res)
         return
             let $res-path := $path || "/" || $res
             let $res-uri := xs:anyURI($res-path)
-            return map {
-                "name": xmldb:decode-uri(xs:anyURI($res)),
-                "isCollection": false(),
-                "path": xmldb:decode-uri(xs:anyURI($res-path)),
-                "mime": xmldb:get-mime-type($res-path),
-                "writable": sm:has-access($res-uri, "w"),
-                "lastModified": string(xmldb:last-modified($path, $res)),
-                "permissions": sm:get-permissions($res-uri)/sm:permission/string(@mode),
-                "owner": sm:get-permissions($res-uri)/sm:permission/string(@owner),
-                "group": sm:get-permissions($res-uri)/sm:permission/string(@group)
-            }
+            let $name := xmldb:decode-uri(xs:anyURI($res))
+            let $disp-path := xmldb:decode-uri(xs:anyURI($res-path))
+            return
+                try {
+                    map {
+                        "name": $name,
+                        "isCollection": false(),
+                        "path": $disp-path,
+                        "mime": xmldb:get-mime-type($res-path),
+                        "accessible": sm:has-access($res-uri, "r"),
+                        "writable": sm:has-access($res-uri, "w"),
+                        "lastModified": string(xmldb:last-modified($path, $res)),
+                        "permissions": sm:get-permissions($res-uri)/sm:permission/string(@mode),
+                        "owner": sm:get-permissions($res-uri)/sm:permission/string(@owner),
+                        "group": sm:get-permissions($res-uri)/sm:permission/string(@group)
+                    }
+                } catch * {
+                    db:inaccessible-entry($name, false(), $disp-path, $err:description)
+                }
     )
     let $total := count($all-items)
     let $path-uri := xs:anyURI($path)

--- a/src/directory.js
+++ b/src/directory.js
@@ -734,7 +734,14 @@ eXide.edit.Directory = (function () {
 		list.innerHTML = '<li class="dir-flat-loading">Loading\u2026</li>';
 
 		fetch(apiPath(collection))
-			.then(function(r) { return r.json(); })
+			.then(function(r) {
+				if (!r.ok) {
+					return r.json().then(
+						function(e) { throw new Error(e && e.error ? e.error : "HTTP " + r.status); },
+						function() { throw new Error("HTTP " + r.status); });
+				}
+				return r.json();
+			})
 			.then(function(data) {
 				list.innerHTML = "";
 				var items = (data.items || []).map(mapItem);
@@ -782,8 +789,9 @@ eXide.edit.Directory = (function () {
 					list.appendChild(li);
 				});
 			})
-			.catch(function() {
-				list.innerHTML = '<li class="dir-flat-empty">Failed to load</li>';
+			.catch(function(err) {
+				list.innerHTML = '<li class="dir-flat-empty">Could not open collection: ' +
+					escapeHtml(err && err.message ? err.message : "Failed to load") + '</li>';
 			});
 	}
 

--- a/src/resources.js
+++ b/src/resources.js
@@ -643,7 +643,14 @@ eXide.browse.ResourceBrowser = (function () {
 			params.set("filter", this._filter);
 		}
 		fetch(apiPath(this._collection) + "?" + params.toString())
-			.then(function(r) { return r.json(); })
+			.then(function(r) {
+				if (!r.ok) {
+					return r.json().then(
+						function(e) { throw new Error(e && e.error ? e.error : "HTTP " + r.status); },
+						function() { throw new Error("HTTP " + r.status); });
+				}
+				return r.json();
+			})
 			.then(function(json) {
 				self.loading = false;
 				if (!json || !json.items) return;
@@ -670,6 +677,11 @@ eXide.browse.ResourceBrowser = (function () {
 					self._updateSelectionDisplay();
 					self._fireSelectionChanged();
 				}
+			})
+			.catch(function(err) {
+				self.loading = false;
+				eXide.util.error("Could not list collection: " +
+					(err && err.message ? err.message : err));
 			});
 	};
 


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Expanding `/db/system` in the eXide tree as **guest** failed, and the failure was swallowed silently. Two issues — one server, one client.

## Server — one unreadable child 500s the whole listing

`db:browse-collection` (`modules/api/db.xqm`) built each child entry inline with `sm:get-permissions()` and **no try/catch**. `/db/system/security` is `rwxrwx---`, so guest can't retrieve its permissions, `sm:get-permissions` throws, and the entire `/db/system` listing returns **HTTP 500** — guest can't see even the world-readable `config`/`repo`.

Now each child's metadata build is wrapped: an unreadable child degrades to `{ name, isCollection, path, accessible: false, error }` instead of failing the listing, and **every entry carries an `accessible` flag** (`sm:has-access` `r`) so the client can render a locked node without re-deriving permissions. Same shape as existdb-openapi#72 / #69.

## Client — the 500 was swallowed

The storage-browse fetch in `src/resources.js` (db-manager grid) and `src/directory.js` (navigator flat view) called `response.json()` **without checking `response.ok`**, so a `500 { error }` body parsed cleanly, produced no `items`, and vanished — the grid rendered nothing, the flat view showed "Empty collection". Both now check `response.ok`, throw the server's error message, and surface it: the grid via `eXide.util.error`, the flat view inline.

## Tests

- **`cypress/e2e/storage_listing_resilience_spec.cy.js`:** guest `GET /api/storage/db/system` returns **200** with `config`/`repo` `accessible: true` and `security` `accessible: false` (was 500); admin listings carry `accessible: true` on every entry.
- `dbmanager_spec` still passes (22/22) — the client `response.ok` guards don't regress normal browsing.

Verified on a bed: guest `/db/system` is 200 with the locked child degraded (reproduced the prior 500 on a clean build first).

## Convergence note

When `/api/storage` is delegated to db-core's `dbc:list` (the thin-adapter direction), this resilience *and* the `accessible` flag come for free — and this local fix can be retired. Until then it needs handling in eXide's own listing code, which db-core's `/api/db` fix doesn't reach.
