### PR TITLE
ci: test both the declared dependencies and eXist-db's bundled ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
          exist-version: [latest]
          # Node 22 is EOL; track current Node LTS (24).
          node-version: ['24']
+         # Two beds, two questions (eXide#821, eXide#865):
+         #   declared — do the dependency versions declared in expath-pkg.xml
+         #              actually run the app? Nothing else is installed.
+         #   bundled  — does the app work with what eXist-db ships by default?
+         #              The build under test is installed over the bundled copy.
+         deps: [declared, bundled]
 
     steps:
       - uses: actions/checkout@v7
@@ -42,18 +48,37 @@ jobs:
       - name: Build frontend Using node.js ${{ matrix.node-version }} and build EXPath Package
         run: npm run build
 
-      - name: Download Roaster dependency
-        run: gh release download v1.12.0 --repo eeditiones/roaster --pattern "roaster-1.12.0.xar" --output build/roaster-1.12.0.xar
+      # The versions come from expath-pkg.xml rather than being hardcoded here,
+      # so this bed tests the contract eXide publishes to the Package Manager.
+      # If a declared minimum is wrong, this leg fails and the declaration is
+      # what needs fixing.
+      - name: Resolve the declared dependencies
+        if: matrix.deps == 'declared'
+        id: declared
+        run: |
+          # Reads the semver-min values out of expath-pkg.xml; fails if any
+          # dependency declares none. Node, not xmllint — the runner image does
+          # not ship libxml2-utils.
+          eval "$(node tools/read-declared-deps.js)"
+          echo "Declared minimums: roaster $ROASTER, existdb-openapi $OPENAPI"
+          gh release download "v$ROASTER" --repo eeditiones/roaster \
+            --pattern "roaster-$ROASTER.xar" --output "build/roaster-$ROASTER.xar"
+          gh release download "v$OPENAPI" --repo eXist-db/existdb-openapi \
+            --pattern "existdb-openapi-*.xar" --dir build/
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Download existdb-openapi dependency
-        run: gh release download v0.9.5 --repo eXist-db/existdb-openapi --pattern "existdb-openapi-*.xar" --dir build/
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Start eXist-db Docker Container
+      # declared: only the built xar and its declared dependencies are present.
+      - name: Start eXist-db with the declared dependencies
+        if: matrix.deps == 'declared'
         run: docker run --rm --name exist --volume $(pwd)/build:/exist/autodeploy:ro --publish 8080:8080 --detach existdb/existdb:${{ matrix.exist-version }}
+
+      # bundled: stock image, nothing removed or extracted; the freshly built
+      # xar is installed over the bundled eXide once the server is up, so the
+      # app under test is unambiguously the one this run compiled.
+      - name: Start eXist-db with its own bundled packages
+        if: matrix.deps == 'bundled'
+        run: docker run --rm --name exist --publish 8080:8080 --detach existdb/existdb:${{ matrix.exist-version }}
 
       - name: Wait for eXist-db Startup and Package Deployment
         run: |
@@ -69,6 +94,16 @@ jobs:
           echo "Timed out waiting for eXide"
           exit 1
 
+      - name: Install the freshly built eXide over the bundled one
+        if: matrix.deps == 'bundled'
+        run: |
+          npx --yes @existdb/xst package install local build/eXide-*.xar --force
+          npx --yes @existdb/xst list --extended | grep -E 'eXide|roaster|openapi' || true
+        env:
+          EXISTDB_SERVER: http://localhost:8080
+          EXISTDB_USER: admin
+          EXISTDB_PASS: ''
+
       - name: Run Cypress Integration Tests
         run: npx cypress run --spec 'cypress/e2e/*.cy.js'
 
@@ -76,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: cypress-screenshots-${{ matrix.exist-version }}-${{ matrix.node-version }}
+          name: cypress-screenshots-${{ matrix.deps }}-${{ matrix.exist-version }}-${{ matrix.node-version }}
           path: cypress/screenshots
 
       # Test run video was always captured, so this action uses "always()" condition
@@ -84,7 +119,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: cypress-videos-${{ matrix.exist-version }}-${{ matrix.node-version }}
+          name: cypress-videos-${{ matrix.deps }}-${{ matrix.exist-version }}-${{ matrix.node-version }}
           path: cypress/videos
 
   # TODO: Add upload to dockerhub

--- a/tools/read-declared-deps.js
+++ b/tools/read-declared-deps.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Print the package dependencies declared in expath-pkg.xml as shell variable
+ * assignments, so CI installs exactly the versions eXide publishes as its
+ * contract rather than versions hardcoded in the workflow (eXide#865).
+ *
+ * Usage: eval "$(node tools/read-declared-deps.js)"
+ *
+ * Exits non-zero if a dependency carries no semver-min: an undeclared minimum
+ * is what let eXide 4.0.1 be paired with an existdb-openapi that could not
+ * report query errors (eXide#821).
+ */
+const fs = require('fs')
+
+// EXPath package name -> shell variable to emit.
+const WANTED = {
+    'http://e-editiones.org/roaster': 'ROASTER',
+    'http://exist-db.org/pkg/openapi': 'OPENAPI'
+}
+
+const xml = fs.readFileSync('expath-pkg.xml', 'utf8')
+const missing = []
+const lines = []
+
+for (const [pkg, name] of Object.entries(WANTED)) {
+    const tag = xml.match(
+        new RegExp('<dependency\\b[^>]*package="' + pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '"[^>]*>')
+    )
+    const min = tag && tag[0].match(/semver-min="([^"]+)"/)
+    if (min) {
+        lines.push(name + '=' + min[1])
+    } else {
+        missing.push(pkg + (tag ? ' (declared, but with no semver-min)' : ' (not declared at all)'))
+    }
+}
+
+if (missing.length) {
+    console.error('expath-pkg.xml must declare a semver-min for every package dependency.')
+    console.error('Missing:\n  ' + missing.join('\n  '))
+    process.exit(1)
+}
+
+console.log(lines.join('\n'))


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Problem

The workflow started the test container with:

```yaml
docker run --volume $(pwd)/build:/exist/autodeploy:ro ... existdb/existdb:latest
```

A bind mount *replaces* the directory, so everything the eXist-db image ships in `/exist/autodeploy` was discarded and CI deployed exactly three packages: the freshly built eXide, plus the two the workflow downloaded — `roaster-1.12.0` and `existdb-openapi-0.9.5`.

That is not the stack anyone runs. `existdb/existdb:latest` bundles:

```
dashboard-2.0.9.xar                      monex-5.1.0.xar
eXide-4.0.1.xar                          packageservice-1.3.14.xar
exist-documentation-7.0.0.xar            roaster-1.12.2.xar
exist-function-documentation-3.0.1.xar   semver-xq-3.0.0.xar
existdb-openapi-0.10.0.xar               templating-1.2.1.xar
functx-1.0.1.xar
```

eXide's own README tells contributors to `docker cp ./build/*.xar exist-ci:exist/autodeploy`, which *layers* onto that set — so the documented local procedure and CI have been testing different stacks.

## The pins are now actively broken

As of today's `existdb/existdb:latest`, the pinned `roaster-1.12.0` cannot serialize eXide's login response, so `POST /api/auth/session` returns:

```
400  Error while serializing xml: org.xml.sax.SAXException:
     err:SENR0001 Cannot serialize a map(*) with the XML or text output method
```

Every spec calls `cy.loginXHR` first, so the whole suite fails — 100% of specs, on any branch. Isolated locally against the same image, with only the Roaster version changed:

| eXide | Roaster | existdb-openapi | `POST /api/auth/session` |
|---|---|---|---|
| `develop` | 1.12.0 (the pin) | 0.9.5 (the pin) | **400** |
| `develop` | 1.12.2 (bundled) | 0.9.5 (the pin) | 200 |
| `develop` | 1.12.2 (bundled) | 0.10.0 (bundled) | 200 |

`develop`'s last green run predates this; the next push to `develop` goes red. This PR is the fix.

## Why the divergence mattered before that

This is also what made eXide#821 unresolvable for two months. The pinned `existdb-openapi-0.9.5` predates the `/api/query` error-envelope regression, so CI stayed green while every user on a stock eXist-db 7 hit a query error eXide could not display. Reproduced on a clean container, same eXist-db build, same query:

| existdb-openapi | `/api/query` response to `1 + "oops"` | query-error specs |
|---|---|---|
| 0.9.5 (the pin) | `HTTP 500` + `{ code, line, column, description }` | pass |
| 0.9.7 (shipped with 7.0.0-beta3) | `HTTP 200` + `{ error: "Invalid context-item: …" }` | fail |
| 0.10.0 (current) | `HTTP 400` + `{ code, message, line, column, raw }` | fail without #840 |

The pins also block PRs: eXide#814 requires Roaster >= 1.12.1 and cannot pass on a bed that supplies 1.12.0.

## Change

Assemble the autodeploy set from the image's own packages, with only eXide swapped for the build under test:

```yaml
CID=$(docker create existdb/existdb:latest)
docker cp "$CID":/exist/autodeploy/. autodeploy/
rm -f autodeploy/eXide-*.xar
cp build/eXide-*.xar autodeploy/
```

The two `gh release download` steps go away with the pins. Copying the set out and mounting it (rather than `docker cp`ing the xar in) keeps the deployment deterministic: exactly one eXide, even across a version bump.

## Merge ordering

CI is red right now regardless of this PR, so this is about the shortest path back to green rather than about avoiding a regression.

**Merge eXide#840 first, then this.** Against the bundled existdb-openapi 0.10.0, `query_error_structured_spec` fails on current `develop` — the real incompatibility this PR stops hiding, and #840 is its fix. With #840 in, this PR takes the suite to fully green on the stack users actually run.

## Verification

Full 39-spec suite, clean container each run, `existdb/existdb:latest` (7.0.0-SNAPSHOT, build 2026-08-18):

- `develop` + bundled packages (openapi 0.10.0): 1 failing — `query_error_structured`, per the ordering note above
- `develop` + eXide#840 + bundled packages: query-error specs pass
- `develop` + the old CI pins (roaster 1.12.0, openapi 0.9.5, no other apps): **all 38 specs fail at login**, per the table above
