### PR TITLE
fix(package): declare the dependency versions eXide actually needs

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="4.0.0" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="4.0.1" spec="1.0">
     <title>eXide - XQuery IDE</title>
     <dependency processor="http://exist-db.org" semver-min="7.0.0-SNAPSHOT"/>
-    <dependency package="http://e-editiones.org/roaster" semver-min="1.8.0"/>
-    <dependency package="http://exist-db.org/pkg/openapi"/>
+    <dependency package="http://e-editiones.org/roaster" semver-min="1.12.2"/>
+    <dependency package="http://exist-db.org/pkg/openapi" semver-min="0.10.0"/>
 </package>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,6 +2,6 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="{{version}}" spec="1.0">
     <title>eXide - XQuery IDE</title>
     <dependency processor="http://exist-db.org" semver-min="7.0.0-SNAPSHOT"/>
-    <dependency package="http://e-editiones.org/roaster" semver-min="1.8.0"/>
-    <dependency package="http://exist-db.org/pkg/openapi"/>
+    <dependency package="http://e-editiones.org/roaster" semver-min="1.12.2"/>
+    <dependency package="http://exist-db.org/pkg/openapi" semver-min="0.10.0"/>
 </package>


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Problem

`expath-pkg.xml` declares:

```xml
<dependency package="http://e-editiones.org/roaster" semver-min="1.8.0"/>
<dependency package="http://exist-db.org/pkg/openapi"/>
```

Roaster's floor is off by four minor versions, and existdb-openapi has no minimum at all — so the Package Manager will pair eXide 4.x with versions it cannot run on, silently. That is how the failures reported in #821 reached users, and why CI could pin existdb-openapi 0.9.5 and still call itself green.

## Measurements

Varying only the Roaster version against eXist-db 7.0.0-SNAPSHOT with eXide `develop`, `POST /api/auth/session`:

| Roaster | result |
|---|---|
| 1.12.0 | 400 — `err:SENR0001 Cannot serialize a map(*) with the XML or text output method` |
| 1.12.1 | 400 — same |
| **1.12.2** | **200** |
| 1.13.0 | 200 |

So the true minimum is 1.12.2 — not the declared 1.8.0, and not the 1.12.1 quoted during the #814 review.

For existdb-openapi, 0.10.0 is the first release carrying the `/api/query` error envelope eXide's error display targets (eXist-db/existdb-openapi#46 and eXist-db/existdb-openapi#71). Earlier releases either swallow query errors as HTTP 200 (0.9.6, 0.9.7) or predate the current structured payload.

## Change

```xml
<dependency package="http://e-editiones.org/roaster" semver-min="1.12.2"/>
<dependency package="http://exist-db.org/pkg/openapi" semver-min="0.10.0"/>
```

in both `expath-pkg.xml` and `expath-pkg.xml.tmpl`.

## Why now

#865 splits CI into a `declared` leg and a `bundled` leg, per @duncdrum's review there. The declared leg resolves its versions *from this file* and installs only those, so it asserts that what eXide publishes to the Package Manager is what the app actually runs on. That leg cannot pass until these declarations are right, which makes this PR a prerequisite for #865.

## Verification

Built the xar and deployed it against exactly the declared minimums (Roaster 1.12.2, existdb-openapi 0.10.0, no other packages): the app installs, login returns 200, and the suite runs 261 tests with only `query_error_structured` failing, which #840 fixes.
