### PR TITLE
test(cypress): make specs independent of one another

### DIFF
--- a/cypress/e2e/apply_configuration.cy.js
+++ b/cypress/e2e/apply_configuration.cy.js
@@ -1,6 +1,13 @@
+/**
+ * Each test owns its collection: it is created before the test and removed
+ * after, and any file a test needs is seeded rather than inherited from the
+ * test before it. With retries enabled (#866) Cypress re-runs only the failing
+ * test, not the ones that built its fixture, so shared state makes a retry
+ * meaningless.
+ */
 describe('Apply configuration', () => {
-  // Use /db which always exists; clean up test files after
-  const testCollection = '/db/test-collection-' + Date.now()
+  // Assigned per test in beforeEach, so no two tests share a collection.
+  let testCollection
   const testFile = 'testcontent.xml'
   const testConfigFile = 'collection.xconf'
   const testConfig = `<collection xmlns="http://exist-db.org/collection-config/1.0">
@@ -11,13 +18,10 @@ describe('Apply configuration', () => {
     </index>
 </collection>`
 
-  before(() => {
-    cy.loginXHR('admin', '')
-    createTestCollection(testCollection)
-  })
-
   beforeEach(() => {
     cy.loginXHR('admin', '')
+    testCollection = `/db/test-collection-${Date.now()}-${Cypress._.random(1000, 9999)}`
+    createTestCollection(testCollection)
     cy.visit('/eXide/index.html')
     cy.reload(true)
     cy.get('.path', { timeout: 10000 }).should('contain', 'untitled-1')
@@ -95,10 +99,17 @@ describe('Apply configuration', () => {
       .find('.eXide-dialog-buttons button').contains("Create").click()
   }
 
-  after(() => {
+  afterEach(() => {
     cy.loginXHR('admin', '')
     cleanTestCollection(testCollection)
   })
+
+  // Seed a resource server-side, so a test about *applying* a configuration
+  // does not depend on the test that is about *saving* one.
+  function seedResource(collection, name, content) {
+    cy.execXQuery(`xquery version "3.1";
+      xmldb:store("${collection}", "${name}", ${content})`)
+  }
 
   it('saves a new test file to the database', () => {
     openNewXMLFile()
@@ -141,7 +152,10 @@ describe('Apply configuration', () => {
   })
 
   it('saves the configuration and shows the apply configuration dialog', () => {
-    // Open the file we saved in the previous test directly
+    // Seed the configuration this test is about saving, rather than relying on
+    // the previous test having saved one.
+    seedResource(testCollection, testConfigFile, `document {${testConfig}}`)
+
     openFileDirectly(testCollection + '/' + testConfigFile)
     cy.get('.path', { timeout: 10000 }).should('contain', testConfigFile)
 

--- a/cypress/e2e/dbmanager_spec.cy.js
+++ b/cypress/e2e/dbmanager_spec.cy.js
@@ -1,22 +1,72 @@
-const collectionName = 'abc'
+/**
+ * Each test drives one DB Manager workflow end to end and owns the collections
+ * it touches: unique names per test, and an afterEach sweep so a failure cannot
+ * leave residue for the next test to trip over.
+ *
+ * Previously each workflow was split across several `it`s — "create", then
+ * "rename", then "delete" — so the later ones depended on the earlier ones
+ * having run, and the copy and cut blocks even shared two collection names, so
+ * a failure in copy's cleanup broke cut. With retries enabled (#866) Cypress
+ * re-runs only the failing test and not the ones that built its state, which
+ * makes that shape actively misleading.
+ */
+const PREFIX = 'cypress-dbmgr-'
+
+function uniqueName(label) {
+  return `${PREFIX}${label}-${Cypress._.random(1000, 9999)}`
+}
 
 function openDbManager() {
   cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a').click()
   cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul').find('#menu-file-manager').click()
 }
 
-function cleanupTestCollections() {
+function removeTestCollections() {
   cy.loginXHR('admin', '')
   cy.execXQuery(`xquery version "3.1";
-    for $col in ("${collectionName}", "def", "AéB")
-    where xmldb:collection-available("/db/" || $col)
+    for $col in xmldb:get-child-collections("/db")
+    where starts-with($col, "${PREFIX}")
     return xmldb:remove("/db/" || $col)`)
 }
 
-context('DB Manager', () => {
-  before(() => { cleanupTestCollections() })
-  after(() => { cleanupTestCollections() })
+// ── DB Manager UI helpers ──────────────────────────────────────────────────
+function createCollection(name) {
+  cy.get('#eXide-browse-toolbar-create').click()
+  cy.get('#eXide-browse-collection-name').type(name)
+  cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
+  shouldList(name)
+}
 
+function shouldList(name) {
+  cy.get('div.eXide-browse-main').within(() => {
+    cy.contains('.browse-table tbody td.col-name', name, { timeout: 5000 }).should('exist')
+  })
+}
+
+function shouldNotList(name) {
+  cy.get('div.eXide-browse-main').within(() => {
+    cy.contains('.browse-table tbody td.col-name', name, { timeout: 5000 }).should('not.exist')
+  })
+}
+
+function select(name) {
+  cy.get('div.eXide-browse-main').within(() => {
+    cy.contains('.browse-table tbody td.col-name', name).click()
+  })
+}
+
+function openCollection(name) {
+  cy.get('div.eXide-browse-main').within(() => {
+    cy.contains('.browse-table tbody td.col-name', name).dblclick()
+  })
+}
+
+function deleteSelected() {
+  cy.get('#eXide-browse-toolbar-delete-resource').click()
+  cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
+}
+
+context('DB Manager', () => {
   describe('DB Manager operations', () => {
     beforeEach(() => {
       cy.loginXHR('admin', '')
@@ -27,6 +77,10 @@ context('DB Manager', () => {
       })
       cy.dismissDialog()
       openDbManager()
+    })
+
+    afterEach(() => {
+      removeTestCollections()
     })
 
     it('should open the db manager', () => {
@@ -40,98 +94,114 @@ context('DB Manager', () => {
         cy.get('.browse-table tbody tr').first().should('have.attr', 'aria-selected', 'true')
       })
     })
-    describe('collection creation', () => {
-      it('should create a new collection', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type(collectionName)
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
 
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', collectionName).should('exist')
-        })
-      })
+    it('creates a collection and deletes it again', () => {
+      const name = uniqueName('abc')
 
-      it('should delete the created collection', () => {
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', collectionName).click()
-        })
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', collectionName).should('not.exist')
-        })
+      createCollection(name)
+
+      select(name)
+      deleteSelected()
+      shouldNotList(name)
+    })
+
+    it('renames a collection', () => {
+      // The new name carries non-ASCII deliberately: the xmldb:* functions
+      // escape those internally, so a rename exercises the encoding round trip.
+      const name = uniqueName('toBeRenamed')
+      const renamed = uniqueName('AéB')
+
+      createCollection(name)
+
+      select(name)
+      cy.get('#eXide-browse-toolbar-rename').click()
+      cy.focused().clear().type(`${renamed}{enter}`)
+
+      shouldList(renamed)
+      shouldNotList(name)
+    })
+
+    it('shows properties for a collection', () => {
+      const name = uniqueName('AéB')
+
+      createCollection(name)
+
+      select(name)
+      cy.get('#eXide-browse-toolbar-properties').click()
+
+      cy.contains('Resource/collection properties').should('be.visible')
+    })
+
+    it('copies a collection into another collection', () => {
+      const source = uniqueName('toBeCopiedAéB')
+      const target = uniqueName('toBeCopiedInAéB')
+
+      createCollection(source)
+      createCollection(target)
+
+      select(source)
+      cy.get('#eXide-browse-toolbar-copy').click()
+
+      openCollection(target)
+      cy.get('#eXide-browse-toolbar-paste').click()
+
+      // The copy landed inside the target…
+      shouldList(source)
+      // …and the original is still where it was.
+      cy.request('/eXide/api/storage/db').then((response) => {
+        expect(response.body.items.map((item) => item.name)).to.include(source)
       })
     })
 
-    describe('renaming operation', () => {
-      it('should create a new collection', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type('toBeRenamed')
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
+    it('cuts a collection into another collection', () => {
+      const source = uniqueName('toBeCutAéB')
+      const target = uniqueName('toBeCutInAéB')
 
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeRenamed').should('exist')
-        })
-      })
+      createCollection(source)
+      createCollection(target)
 
-      it('should rename selected', () => {
-        //click on file by name
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeRenamed').click()
-        })
-        //click on toolbar action
-        cy.get('#eXide-browse-toolbar-rename').click()
-        cy.focused().type('AéB{enter}')
+      select(source)
+      cy.get('#eXide-browse-toolbar-cut').click()
 
-        //check for modification
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB', { timeout: 5000 }).should('exist')
-        })
-      })
+      openCollection(target)
+      cy.get('#eXide-browse-toolbar-paste').click()
 
-      it('should delete the created collection', () => {
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').click()
-        })
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').should('not.exist')
-        })
+      shouldList(source)
+      // …and unlike a copy, the original is gone from where it came from.
+      // Asserted against the storage API rather than by navigating back up,
+      // since the browser has no "up" control — parent navigation is bound to
+      // backspace on the table.
+      cy.request('/eXide/api/storage/db').then((response) => {
+        expect(response.body.items.map((item) => item.name)).to.not.include(source)
       })
     })
 
-    describe('properties operation', () => {
-      it('should create a new collection', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type('AéB')
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
+    it('opens a resource created outside the UI, then deletes its collection', () => {
+      const name = uniqueName('AéB')
 
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').should('exist')
-        })
+      cy.execXQuery(`xquery version "3.1";
+        xmldb:create-collection("/db", "${name}"),
+        xmldb:store(xmldb:encode("/db/${name}"), xmldb:encode("AéB.xml"), <foo/>)`)
+
+      // Re-open the manager so the new collection is listed.
+      cy.visit('/eXide/index.html')
+      cy.dismissDialog()
+      openDbManager()
+
+      openCollection(name)
+      cy.get('div.eXide-browse-main').within(() => {
+        cy.contains('.browse-table tbody td.col-name', 'AéB.xml').dblclick()
       })
 
-      it('should check for properties', () => {
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').click()
-        })
+      cy.contains(`/db/${name}/AéB.xml`).should('be.visible')
+      cy.get('#close').click()
 
-        cy.get('#eXide-browse-toolbar-properties').click()
-
-        cy.contains('Resource/collection properties').should('be.visible')
-      })
-
-      it('should delete the created collection', () => {
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').click()
-        })
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').should('not.exist')
-        })
-      })
+      cy.visit('/eXide/index.html')
+      cy.dismissDialog()
+      openDbManager()
+      select(name)
+      deleteSelected()
+      shouldNotList(name)
     })
 
     describe('resource properties for README.md', () => {
@@ -177,185 +247,6 @@ context('DB Manager', () => {
           // Confirm owner/group selects exist
           cy.get('select[name="owner"]').should('exist')
           cy.get('select[name="group"]').should('exist')
-        })
-      })
-    })
-
-    describe('copy operation', () => {
-      it('should create collection to be copied', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type('toBeCopiedAéB')
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').should('exist')
-        })
-      })
-
-      it('should create collection to be copied in', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type('toBeCopiedInAéB')
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').should('exist')
-        })
-      })
-
-      it('should copy the collection', () => {
-        //click on file by name
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').click()
-        })
-        //click on toolbar action
-        cy.get('#eXide-browse-toolbar-copy').click()
-
-        //navigate into collection
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').dblclick()
-        })
-
-        //paste the collection
-        cy.get('#eXide-browse-toolbar-paste').click()
-
-        //check for modification
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').should('exist')
-        })
-      })
-
-      it('should delete the created collection', () => {
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').click()
-        })
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB', { timeout: 5000 }).should('not.exist')
-        })
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').click()
-        })
-
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').should('not.exist')
-        })
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').should('not.exist')
-        })
-      })
-    })
-
-    describe('cut operation', () => {
-      it('should create collection to be copied', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type('toBeCopiedAéB')
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').should('exist')
-        })
-      })
-
-      it('should create collection to be copied in', () => {
-        cy.get('#eXide-browse-toolbar-create').click()
-        cy.get('#eXide-browse-collection-name').type('toBeCopiedInAéB')
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').should('exist')
-        })
-      })
-
-      it('should cut the collection', () => {
-        //click on file by name
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').click()
-        })
-        //click on toolbar action
-        cy.get('#eXide-browse-toolbar-cut').click()
-
-        //navigate into collection
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').dblclick()
-        })
-
-        //paste the collection
-        cy.get('#eXide-browse-toolbar-paste').click()
-
-        //check for modification
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').should('exist')
-        })
-      })
-
-      it('should delete the created collection', () => {
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').click()
-        })
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedInAéB').should('not.exist')
-        })
-        // check the collection is removed by cutting it
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'toBeCopiedAéB').should('not.exist')
-        })
-      })
-    })
-
-    describe('create resource', () => {
-      it('should create resource using xmldb', () => {
-        cy.request({
-          method: 'POST',
-          url: `/eXide/execute`,
-          form: true,
-          body: {
-            qu: `xquery version "3.1";
-
-            xmldb:create-collection("/db","AéB"),
-            xmldb:store(xmldb:encode("/db/AéB"), xmldb:encode("AéB.xml"), <foo/>)`,
-            base: 'xmldb:exist://__new__1',
-            output: 'adaptive'
-          }
-        })
-      })
-
-      it('should open resource', () => {
-        cy.visit(`/eXide/index.html`)
-        cy.dismissDialog()
-        cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a').click()
-        cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul').find('#menu-file-manager').click()
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').dblclick()
-          cy.contains('.browse-table tbody td.col-name', 'AéB.xml').dblclick()
-        })
-
-        cy.contains('/db/AéB/AéB.xml').should('exist')
-        cy.contains('/db/AéB/AéB.xml').should('be.visible')
-
-        cy.get('#close').click()
-      })
-
-      it('should delete the created collection', () => {
-        cy.visit(`/eXide/index.html`)
-        cy.dismissDialog()
-        cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > a').click()
-        cy.get('#fullscreen > div.editor-header > div > ul > li:nth-child(1) > ul').find('#menu-file-manager').click()
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').click()
-        })
-        cy.get('#eXide-browse-toolbar-delete-resource').click()
-        cy.get('dialog.eXide-dialog[open] .eXide-dialog-buttons button:first-of-type').click()
-
-        cy.get('div.eXide-browse-main').within(() => {
-          cy.contains('.browse-table tbody td.col-name', 'AéB').should('not.exist')
         })
       })
     })

--- a/cypress/e2e/file_save_spec.cy.js
+++ b/cypress/e2e/file_save_spec.cy.js
@@ -1,13 +1,29 @@
+/**
+ * Each test here owns its state: it seeds whatever file it needs and cleans up
+ * after itself, so no test depends on one that ran before it. That matters now
+ * that the suite runs with retries (#866) — Cypress retries only the failing
+ * test, not the ones that set up its state, so a chained spec retried against
+ * a half-built fixture can pass or fail for reasons unrelated to the failure.
+ */
 describe('File save', () => {
-  // Use /db which always exists; clean up test files after
-  var testCollection = '/db'
-  var testFile = 'cypress-test-' + Date.now() + '.xq'
+  const testCollection = '/db'
 
-  before(() => {
-    cy.cleanupTestFiles()
-  })
+  // Unique per test, so a leftover from an earlier run can never satisfy an
+  // assertion here. The `cypress-test-` prefix is what cleanupTestFiles sweeps.
+  function newFileName() {
+    return `cypress-test-${Date.now()}-${Cypress._.random(1000, 9999)}.xq`
+  }
+
+  // Seed a file server-side rather than by driving the UI, so tests that are
+  // about *opening* or *re-saving* a file do not silently depend on the test
+  // that is about saving one.
+  function seedFile(name, content) {
+    cy.execXQuery(`xquery version "3.1";
+      xmldb:store("${testCollection}", "${name}", "${content}", "application/xquery")`)
+  }
 
   beforeEach(() => {
+    cy.cleanupTestFiles()
     cy.loginXHR('admin', '')
     cy.visit('/eXide/index.html')
     cy.reload(true)
@@ -15,9 +31,13 @@ describe('File save', () => {
     cy.get('#user', { timeout: 10000 }).should('not.have.text', 'Login')
   })
 
+  afterEach(() => {
+    cy.cleanupTestFiles()
+  })
+
   function setEditorContent(text) {
     cy.window().then((win) => {
-      var doc = win.eXide.app.getEditor().getActiveDocument()
+      const doc = win.eXide.app.getEditor().getActiveDocument()
       doc.setText(text)
     })
   }
@@ -42,15 +62,11 @@ describe('File save', () => {
   }
 
   function openFileDirectly(path) {
-    var name = path.split('/').pop()
+    const name = path.split('/').pop()
     cy.window().then((win) => {
       win.eXide.app.$doOpenDocument({ path: path, name: name })
     })
   }
-
-  after(() => {
-    cy.cleanupTestFiles()
-  })
 
   it('opens the save dialog for a new document', () => {
     setEditorContent('1 + 1')
@@ -65,6 +81,7 @@ describe('File save', () => {
   })
 
   it('saves a new XQuery file to the database', () => {
+    const testFile = newFileName()
     setEditorContent('(: test file :)\n1 + 1')
     cy.get('#save').click()
 
@@ -77,11 +94,18 @@ describe('File save', () => {
     // Dialog should close and path should update
     saveDialogShouldBeClosed()
     cy.get('.path', { timeout: 5000 }).should('contain', testFile)
+
+    // …and the resource is really in the database, not just in the tab label.
+    cy.request(`/eXide/api/storage${testCollection}`).then((response) => {
+      expect(response.body.items.map((item) => item.name)).to.include(testFile)
+    })
   })
 
   it('saves an existing document without opening dialog', () => {
-    // Open the file we saved in the previous test directly
-    openFileDirectly(testCollection + '/' + testFile)
+    const testFile = newFileName()
+    seedFile(testFile, '(: seeded :)&#10;1 + 1')
+
+    openFileDirectly(`${testCollection}/${testFile}`)
     cy.get('.path', { timeout: 10000 }).should('contain', testFile)
 
     // Modify the content
@@ -113,13 +137,15 @@ describe('File save', () => {
   })
 
   it('can open a saved file and verify content', () => {
-    // Open the file we saved and modified earlier
-    openFileDirectly(testCollection + '/' + testFile)
+    const testFile = newFileName()
+    seedFile(testFile, '(: modified :)&#10;2 + 2')
+
+    openFileDirectly(`${testCollection}/${testFile}`)
     cy.get('.path', { timeout: 10000 }).should('contain', testFile)
 
-    // Verify the document was loaded with the modified content
+    // The editor holds what the database holds.
     cy.window().then((win) => {
-      var text = win.eXide.app.getEditor().getActiveDocument().getText()
+      const text = win.eXide.app.getEditor().getActiveDocument().getText()
       expect(text).to.contain('modified')
     })
   })


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Why

Follow-up to @duncdrum's review on #866: the preferred design is no state shared between test cases. It also matters mechanically now that retries are on — Cypress retries only the failing test, not the ones that built its fixture, so a retried test in a chained spec runs against whatever its predecessors left behind and neither outcome tells you anything.

Three specs carried that shape:

- **`file_save_spec`** — three tests operated on the file a fourth test saved
- **`apply_configuration`** — one collection created once for the whole spec, with each test writing into it, and the third test opening the configuration the second one saved
- **`dbmanager_spec`** — every describe block was one workflow split across several `it`s ("create", then "rename", then "delete"), and the copy and cut blocks shared the same two collection names, so a failure in copy's cleanup broke cut

## Change

Every test now owns its state. Each names its own file or collection (unique per test, under a prefix the cleanup sweeps), seeds what it needs server-side rather than through a sibling test's UI flow, and cleans up in `afterEach`. In `dbmanager_spec` each test drives one workflow end to end with assertions along the way, which turns 22 tests into 9 — none of which depend on another.

Three assertions got sharper in the process, all cases where the old split had left a gap:

- the save test asserts the resource is really in the database via `GET /api/storage`, rather than trusting the editor's own path label
- copy and cut previously differed only in which toolbar button they clicked, and neither checked what became of the source; they now assert that a copy leaves the original in place and a cut does not
- the rename test asserts the old name is gone, not just that the new one appeared

## Verification

Against eXist-db 7.0.0-SNAPSHOT with the packages the image bundles:

- all three specs pass as a whole
- **each of their seventeen tests passes when run on its own** (`it.only`, one at a time) — which is the property this PR is actually about
- the database is left with no `cypress-*` collections afterwards
- the full suite still reports only `query_error_structured` failing, which #840 fixes (the total drops from 261 to 248 because `dbmanager_spec`'s 22 tests become 9)

## Note on the test count

The suite reports fewer tests than before (248, down from 261) because `dbmanager_spec`'s create/act/delete sequences are now one test each rather than three. Coverage is the same or slightly better — the steps that used to be separate `it`s are still executed and still asserted, now inside the chain that depends on them.
