### PR TITLE
feat(editor): validate XML with native eXist schemas

### DIFF
--- a/cypress/e2e/xml_validate_spec.cy.js
+++ b/cypress/e2e/xml_validate_spec.cy.js
@@ -1,0 +1,110 @@
+describe('XML validation (api/editor/validate)', () => {
+  beforeEach(() => {
+    cy.loginXHR('admin', '')
+  })
+
+  const validate = (xml) =>
+    cy.request({
+      method: 'POST',
+      url: '/eXide/api/editor/validate',
+      headers: {
+        'Content-Type': 'application/xml',
+        Accept: 'application/json'
+      },
+      body: xml
+    })
+
+  it('accepts a valid collection.xconf via native schema when available', () => {
+    const xml = `<?xml version="1.0"?>
+<collection xmlns="http://exist-db.org/collection-config/1.0">
+  <index/>
+</collection>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'valid')
+      expect(res.body).to.have.property('schema', 'collection.xconf.xsd')
+      // Docker/CI with exist#6528 ships $EXIST_HOME/schema/; assert native path.
+      expect(res.body.grammar).to.equal('native')
+    })
+  })
+
+  it('rejects an invalid collection.xconf', () => {
+    // Empty collection fails the XSD 1.1 assert that at least one of
+    // index / triggers / validation must be present.
+    const xml = `<?xml version="1.0"?>
+<collection xmlns="http://exist-db.org/collection-config/1.0"/>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'invalid')
+      expect(res.body).to.have.property('schema', 'collection.xconf.xsd')
+      expect(res.body.errors).to.be.an('array').that.is.not.empty
+      expect(res.body.errors[0].message).to.match(/assert|count\(\*\)/i)
+    })
+  })
+
+  it('honours xsi:schemaLocation for collection.xconf', () => {
+    const xml = `<?xml version="1.0"?>
+<collection xmlns="http://exist-db.org/collection-config/1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://exist-db.org/collection-config/1.0 collection.xconf.xsd">
+  <index/>
+</collection>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'valid')
+      expect(res.body).to.have.property('schema', 'collection.xconf.xsd')
+      expect(res.body.grammar).to.be.oneOf(['native', 'bundled'])
+    })
+  })
+
+  it('validates expath-pkg.xml', () => {
+    const xml = `<?xml version="1.0"?>
+<package xmlns="http://expath.org/ns/pkg"
+         name="http://example.org/test-pkg"
+         abbrev="test-pkg"
+         version="1.0.0"
+         spec="1.0">
+  <title>Test package</title>
+</package>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'valid')
+      expect(res.body).to.have.property('schema', 'expath-pkg.xsd')
+      expect(res.body.grammar).to.equal('native')
+    })
+  })
+
+  it('validates no-namespace mime-types.xml', () => {
+    const xml = `<?xml version="1.0"?>
+<mime-types>
+  <mime-type name="application/xml" type="xml">
+    <description>XML</description>
+    <extensions>.xml</extensions>
+  </mime-type>
+</mime-types>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'valid')
+      expect(res.body).to.have.property('schema', 'mime-types.xsd')
+      expect(res.body.grammar).to.equal('native')
+    })
+  })
+
+  it('rejects invalid no-namespace mime-types.xml', () => {
+    const xml = `<?xml version="1.0"?>
+<mime-types>
+  <mime-type name="not-a-mime" type="xml">
+    <description>bad</description>
+    <extensions>.xml</extensions>
+  </mime-type>
+</mime-types>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'invalid')
+      expect(res.body).to.have.property('schema', 'mime-types.xsd')
+      expect(res.body.errors).to.be.an('array').that.is.not.empty
+    })
+  })
+
+  it('marks plain XML without a known grammar as well-formed only', () => {
+    const xml = `<?xml version="1.0"?><note><text>hi</text></note>`
+    validate(xml).then((res) => {
+      expect(res.body).to.have.property('status', 'valid')
+      expect(res.body).to.have.property('grammar', 'none')
+    })
+  })
+})

--- a/modules/api.json
+++ b/modules/api.json
@@ -781,7 +781,7 @@
         },
         "/api/editor/validate": {
             "post": {
-                "summary": "Validate XML against schema catalog",
+                "summary": "Validate XML against native eXist grammars when available (XSD 1.1)",
                 "operationId": "editor:validate",
                 "tags": [
                     "editor"

--- a/modules/api/editor.xqm
+++ b/modules/api/editor.xqm
@@ -109,28 +109,286 @@ declare function editor:modules($request as map(*)) {
     }
 };
 
+declare variable $editor:XSD_11 :=
+    "http://www.w3.org/XML/XMLSchema/v1.1";
+
+declare variable $editor:XSI_NS :=
+    "http://www.w3.org/2001/XMLSchema-instance";
+
+declare variable $editor:SCHEMA_DIR_DB :=
+    "/db/apps/eXide/resources/schema/";
+
+(:~
+ : Known eXist grammars keyed by target namespace (exist#6528 native set).
+ :)
+declare variable $editor:SCHEMA_BY_NS := map {
+    "http://exist-db.org/collection-config/1.0": "collection.xconf.xsd",
+    "http://exist.sourceforge.net/NS/exist": "controller-config.xsd",
+    "http://expath.org/ns/pkg": "expath-pkg.xsd",
+    "http://exist-db.org/Configuration": "security-manager.xsd"
+};
+
+(:~
+ : No-namespace eXist config roots → grammar filename.
+ :)
+declare variable $editor:SCHEMA_BY_ROOT := map {
+    "exist": "conf.xsd",
+    "xquery-app": "descriptor.xsd",
+    "mime-types": "mime-types.xsd",
+    "auth": "users.xsd",
+    "server": "server.xsd"
+};
+
+(:~
+ : True when the given filesystem path exists. File module namespace varies by
+ : eXist-db version — same approach as admin:status.
+ :)
+declare function editor:file-exists($path as xs:string) as xs:boolean {
+    let $escaped := replace($path, "'", "''")
+    return
+        try {
+            if ("http://expath.org/ns/file" = util:registered-modules()) then
+                util:eval(
+                    "import module namespace file='http://expath.org/ns/file'; " ||
+                    "file:exists('" || $escaped || "')"
+                )
+            else if ("http://exist-db.org/xquery/file" = util:registered-modules()) then
+                util:eval(
+                    "import module namespace file='http://exist-db.org/xquery/file' " ||
+                    "at 'java:org.exist.xquery.modules.file.FileModule'; " ||
+                    "file:exists('" || $escaped || "')"
+                )
+            else
+                false()
+        } catch * {
+            false()
+        }
+};
+
+(:~
+ : Convert an absolute filesystem path to a file: URI (Unix and Windows).
+ :)
+declare function editor:path-to-file-uri($path as xs:string) as xs:anyURI {
+    let $normalized := replace($path, "\\", "/")
+    let $with-slashes :=
+        if (matches($normalized, "^[A-Za-z]:/")) then
+            "file:///" || $normalized
+        else if (starts-with($normalized, "/")) then
+            "file://" || $normalized
+        else
+            "file:///" || $normalized
+    return
+        xs:anyURI(replace($with-slashes, " ", "%20"))
+};
+
+(:~
+ : Resolve a known grammar filename to native `$EXIST_HOME/schema/` when
+ : present (exist#6528), else the app-bundled fallback (eXide#842).
+ : Returns map { "uri", "source" ("native"|"bundled"), "name" }.
+ :)
+declare function editor:resolve-grammar-file($name as xs:string) as map(*) {
+    let $native := system:get-exist-home() || "/schema/" || $name
+    return
+        if (editor:file-exists($native)) then
+            map {
+                "uri": editor:path-to-file-uri($native),
+                "source": "native",
+                "name": $name
+            }
+        else
+            map {
+                "uri": xs:anyURI($editor:SCHEMA_DIR_DB || $name),
+                "source": "bundled",
+                "name": $name
+            }
+};
+
+(:~
+ : If $hint is a known grammar basename (optionally with path), return it.
+ :)
+declare function editor:known-grammar-name($hint as xs:string?) as xs:string? {
+    if (empty($hint) or $hint eq "") then
+        ()
+    else
+        let $base := replace($hint, "^.*/", "")
+        return
+            if (
+                $base = (
+                    map:keys($editor:SCHEMA_BY_NS) ! $editor:SCHEMA_BY_NS(.),
+                    map:keys($editor:SCHEMA_BY_ROOT) ! $editor:SCHEMA_BY_ROOT(.)
+                )
+            ) then
+                $base
+            else
+                ()
+};
+
+(:~
+ : Prefer xsi:schemaLocation / xsi:noNamespaceSchemaLocation when present,
+ : then namespace map, then no-namespace root map.
+ : Returns map { "uri", "source", "name" } or the empty sequence.
+ :
+ : Interim: uses validation:jaxv-report with an explicit schema URI because
+ : jaxp + system/OASIS catalog does not yet apply native XSD 1.1 grammars
+ : (exist#6686). When that lands, prefer catalog resolution again.
+ :)
+declare function editor:resolve-schema($root as element()) as map(*)? {
+    let $schema-loc-attr :=
+        $root/@*[namespace-uri(.) eq $editor:XSI_NS and local-name(.) eq "schemaLocation"]
+    let $no-ns-loc-attr :=
+        $root/@*[namespace-uri(.) eq $editor:XSI_NS and local-name(.) eq "noNamespaceSchemaLocation"]
+    let $schema-loc :=
+        if (exists($schema-loc-attr)) then normalize-space($schema-loc-attr) else ""
+    let $no-ns-loc :=
+        if (exists($no-ns-loc-attr)) then normalize-space($no-ns-loc-attr) else ""
+    let $from-schema-location :=
+        if ($schema-loc ne "") then
+            let $tokens := tokenize($schema-loc, "\s+")
+            let $pairs :=
+                for $i in (1 to (count($tokens) idiv 2))
+                let $ns := $tokens[($i - 1) * 2 + 1]
+                let $loc := $tokens[($i - 1) * 2 + 2]
+                return
+                    if ($ns eq namespace-uri($root)) then $loc else ()
+            let $loc := head($pairs)
+            return
+                if (empty($loc)) then
+                    ()
+                else if (matches($loc, "^(file:|/db/)")) then
+                    map {
+                        "uri": xs:anyURI($loc),
+                        "source": "instance",
+                        "name": replace($loc, "^.*/", "")
+                    }
+                else
+                    let $known := editor:known-grammar-name($loc)
+                    return
+                        if (exists($known)) then
+                            editor:resolve-grammar-file($known)
+                        else if (map:contains($editor:SCHEMA_BY_NS, namespace-uri($root))) then
+                            editor:resolve-grammar-file($editor:SCHEMA_BY_NS(namespace-uri($root)))
+                        else
+                            ()
+        else
+            ()
+    let $from-no-ns :=
+        if (exists($from-schema-location)) then
+            ()
+        else if ($no-ns-loc ne "") then
+            if (matches($no-ns-loc, "^(file:|/db/)")) then
+                map {
+                    "uri": xs:anyURI($no-ns-loc),
+                    "source": "instance",
+                    "name": replace($no-ns-loc, "^.*/", "")
+                }
+            else
+                let $known := editor:known-grammar-name($no-ns-loc)
+                return
+                    if (exists($known)) then
+                        editor:resolve-grammar-file($known)
+                    else
+                        ()
+        else
+            ()
+    let $from-ns :=
+        if (exists(($from-schema-location, $from-no-ns))) then
+            ()
+        else if (map:contains($editor:SCHEMA_BY_NS, namespace-uri($root))) then
+            editor:resolve-grammar-file($editor:SCHEMA_BY_NS(namespace-uri($root)))
+        else
+            ()
+    let $from-root :=
+        if (exists(($from-schema-location, $from-no-ns, $from-ns))) then
+            ()
+        else if (namespace-uri($root) eq "" and map:contains($editor:SCHEMA_BY_ROOT, local-name($root))) then
+            editor:resolve-grammar-file($editor:SCHEMA_BY_ROOT(local-name($root)))
+        else
+            ()
+    return
+        ($from-schema-location, $from-no-ns, $from-ns, $from-root)[1]
+};
+
+declare function editor:validation-result(
+    $report as element(),
+    $grammar as map(*)?
+) as map(*) {
+    let $base :=
+        if (exists($grammar)) then
+            map {
+                "grammar": $grammar?source,
+                "schema": $grammar?name
+            }
+        else
+            map {
+                "grammar": "none",
+                "schema": ()
+            }
+    return
+        if ($report/status eq "valid") then
+            map:merge(($base, map { "status": "valid" }))
+        else
+            map:merge((
+                $base,
+                map {
+                    "status": "invalid",
+                    "errors": array {
+                        for $msg in $report/message
+                        return map {
+                            "line": (xs:integer($msg/@line), 0)[1],
+                            "message": string($msg)
+                        }
+                    }
+                }
+            ))
+};
+
 (:~
  : POST /api/editor/validate — XML validation.
  : Migrated from validate-xml.xq.
+ :
+ : Resolves a grammar for known eXist/EXPath documents (native
+ : `$EXIST_HOME/schema/` when present — exist#6528 — else bundled copies under
+ : resources/schema/; see eXide#842). Instance xsi:schemaLocation /
+ : noNamespaceSchemaLocation is honoured when it points at a known grammar or
+ : an absolute file:/db URI. Validation uses validation:jaxv-report + XSD 1.1
+ : (interim until exist#6686 restores reliable catalog-based jaxp).
+ :
+ : XML without a resolvable grammar is checked for well-formedness only.
  :)
 declare function editor:validate($request as map(*)) {
     let $xml := $request?body
     let $validate := ($request?parameters?validate, true())[1]
     return
         try {
-            let $parsed :=
-                if ($validate) then
-                    validation:jaxp-parse($xml, true(),
-                        doc("/db/apps/eXide/resources/schema/catalog.xml"))
-                else
-                    parse-xml($xml)
-            return map { "status": "valid" }
+            if (not($validate)) then
+                let $_ :=
+                    if ($xml instance of node()) then $xml
+                    else parse-xml($xml)
+                return map { "status": "valid", "grammar": "none", "schema": () }
+            else
+                let $node :=
+                    if ($xml instance of node()) then $xml
+                    else parse-xml($xml)
+                let $root :=
+                    if ($node instance of document-node()) then $node/*
+                    else $node
+                let $grammar := editor:resolve-schema($root)
+                return
+                    if (exists($grammar)) then
+                        editor:validation-result(
+                            validation:jaxv-report($node, $grammar?uri, $editor:XSD_11),
+                            $grammar
+                        )
+                    else
+                        map { "status": "valid", "grammar": "none", "schema": () }
         } catch * {
             map {
                 "status": "invalid",
+                "grammar": "none",
+                "schema": (),
                 "errors": array {
                     map {
-                        "line": $err:line-number,
+                        "line": ($err:line-number, 0)[1],
                         "message": $err:description
                     }
                 }

--- a/resources/schema/README.md
+++ b/resources/schema/README.md
@@ -1,0 +1,10 @@
+# eXide schema fallbacks (eXide#842)
+
+Copies of eXist-db native grammars from `$EXIST_HOME/schema/` (exist#6528).
+
+`editor:validate` prefers the native files when present; these copies are the
+fallback for older servers. Keep them in sync with exist's `schema/` tree.
+
+Long-term these files (and `catalog.xml`) can be removed once catalog-based
+jaxp validation works against the native set (exist#6686) and unsupported
+servers without `$EXIST_HOME/schema/` are gone.

--- a/resources/schema/catalog.xml
+++ b/resources/schema/catalog.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OASIS catalog for eXist grammars bundled under resources/schema/.
+
+  editor:validate prefers validation:jaxv-report against
+  $EXIST_HOME/schema/<file>.xsd when present (exist#6528), else the sibling
+  copies in this directory (eXide#842). Catalog-based jaxp resolution for these
+  native XSD 1.1 grammars is not yet reliable (exist#6686); this catalog is kept
+  for tooling and for a future switch back to system/OASIS catalog validation.
+
+  Fallback XSDs are synced from exist's schema/ tree and will be removed once
+  older servers without $EXIST_HOME/schema/ are out of support.
+-->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri name="http://exist-db.org/collection-config/1.0" uri="collection.xconf.xsd"/>
+    <uri name="http://exist.sourceforge.net/NS/exist" uri="controller-config.xsd"/>
+    <uri name="http://expath.org/ns/pkg" uri="expath-pkg.xsd"/>
+    <uri name="http://exist-db.org/Configuration" uri="security-manager.xsd"/>
+    <!-- No-namespace configs: resolve by system id / tooling, not by uri name -->
+    <systemSuffix systemIdSuffix="conf.xsd" uri="conf.xsd"/>
+    <systemSuffix systemIdSuffix="descriptor.xsd" uri="descriptor.xsd"/>
+    <systemSuffix systemIdSuffix="mime-types.xsd" uri="mime-types.xsd"/>
+    <systemSuffix systemIdSuffix="users.xsd" uri="users.xsd"/>
+    <systemSuffix systemIdSuffix="server.xsd" uri="server.xsd"/>
+    <systemSuffix systemIdSuffix="schema-version-type.xsd" uri="schema-version-type.xsd"/>
 </catalog>

--- a/resources/schema/collection.xconf.xsd
+++ b/resources/schema/collection.xconf.xsd
@@ -6,13 +6,15 @@
            xmlns:dcterms="http://purl.org/dc/terms/"
            elementFormDefault="qualified"
            targetNamespace="http://exist-db.org/collection-config/1.0"
-           version="1.0.0">
+           version="1.2.2">
+
+    <xs:include schemaLocation="schema-version-type.xsd"/>
 
     <xs:annotation>
         <xs:documentation>Schema for eXist-db Collection Configuration files /db/system/config/db/**/collection.xconf</xs:documentation>
         <xs:appinfo>
             <dcterms:title>Schema for eXist-db Collection Configuration Files</dcterms:title>
-            <dcterms:created xsi:type="dcterms:W3CDTF">2011-10-09T18:47:21.319+01:00</dcterms:created>
+            <dcterms:created>2011-10-09T18:47:21.319+01:00</dcterms:created>
             <dcterms:creator>Adam Retter</dcterms:creator>
         </xs:appinfo>
     </xs:annotation>
@@ -28,6 +30,7 @@
             <xs:element ref="cc:triggers" minOccurs="0"/>
             <xs:element ref="cc:validation" minOccurs="0"/>
         </xs:all>
+        <xs:attribute name="schemaVersion" type="cc:schemaVersionType" use="optional"/>
         <xs:assert test="count(*) ge 1"/>
     </xs:complexType>
     <xs:element name="index" type="cc:indexType"/>
@@ -56,15 +59,15 @@
     </xs:complexType>
 
     <xs:element name="range" type="cc:newRangeIndexType"/>
-
+    
     <xs:complexType name="newRangeIndexType">
         <xs:sequence>
             <xs:element ref="cc:create" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
-
+    
     <xs:element name="create" type="cc:rangeIndexCreateType"/>
-
+    
     <xs:complexType name="rangeIndexCreateType">
         <xs:group ref="cc:fieldDefinitions"/>
         <xs:attributeGroup ref="cc:qnameOpt"/>
@@ -75,14 +78,14 @@
         <xs:attributeGroup ref="cc:caseOpt"/>
         <xs:attributeGroup ref="cc:collationOpt"/>
     </xs:complexType>
-
+    
     <xs:group name="fieldDefinitions">
         <xs:all>
             <xs:element name="condition" type="cc:newRangeIndexConditionType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="field" type="cc:newRangeIndexFieldType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:all>
     </xs:group>
-
+    
     <xs:complexType name="newRangeIndexConditionType">
         <xs:attributeGroup ref="cc:attributeReq"/>
         <xs:attributeGroup ref="cc:operatorOpt"/>
@@ -90,7 +93,7 @@
         <xs:attributeGroup ref="cc:caseOpt"/>
         <xs:attributeGroup ref="cc:numericOpt"/>
     </xs:complexType>
-
+    
     <xs:complexType name="newRangeIndexFieldType">
         <xs:attributeGroup ref="cc:nameReq"/>
         <xs:attributeGroup ref="cc:matchOpt"/>
@@ -99,7 +102,7 @@
         <xs:attributeGroup ref="cc:whitespaceOpt"/>
         <xs:attributeGroup ref="cc:typeOpt"/>
     </xs:complexType>
-
+    
     <xs:element name="lucene" type="cc:luceneType"/>
 
     <xs:complexType name="luceneType">
@@ -143,9 +146,9 @@
         <xs:attribute name="type" type="xs:string" use="optional" default="java.lang.String"/>
         <xs:attributeGroup ref="cc:valueOpt"/>
     </xs:complexType>
-
+    
     <xs:element name="module" type="cc:moduleType"/>
-
+    
     <xs:complexType name="moduleType">
         <xs:attributeGroup ref="cc:uriReq"/>
         <xs:attributeGroup ref="cc:prefixReq"/>
@@ -226,7 +229,7 @@
         <xs:attributeGroup ref="cc:expressionReq"/>
         <xs:attributeGroup ref="cc:hierarchicalOpt"/>
     </xs:complexType>
-
+    
     <xs:complexType name="fieldAttrType">
         <xs:attributeGroup ref="cc:nameReq"/>
         <xs:attributeGroup ref="cc:ifOpt"/>
@@ -267,7 +270,7 @@
             <xs:documentation>Trigger Configuration</xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element ref="cc:trigger" maxOccurs="unbounded"/>
+            <xs:element ref="cc:trigger" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -319,14 +322,14 @@
     </xs:complexType>
 
     <!--
-        We are hiding attributes in attributeGroup to manage their namespaces as
+        We are hiding attributes in attributeGroup to manage their namespaces as 
         described here: http://docstore.mik.ua/orelly/xml/schema/ch10_04.htm.
-        A side benefit of this is centralized definitions attributes that may be
+        A side benefit of this is centralized definitions attributes that may be 
         used by different elements.
         Please keep the entries arranged in alphabetical order for easy lookup.
-        Note that there are -Opt and -Req pairs of many attributes.
-        Ideally we could have just one definition of each attribute, but this
-        is not possible because of form restrictions in XML Schema, so
+        Note that there are -Opt and -Req pairs of many attributes. 
+        Ideally we could have just one definition of each attribute, but this 
+        is not possible because of form restrictions in XML Schema, so 
         @use=required|optional has to be hardcoded in the xs:attributeGroup
         definition.
     -->
@@ -338,7 +341,7 @@
         <xs:attribute name="at" type="xs:anyURI" use="required" form="unqualified"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="attributeReq">
-        <xs:attribute name="attribute" type="xs:NCName" use="required"/>
+        <xs:attribute name="attribute" type="xs:string" use="required"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="binaryOpt">
         <xs:attribute name="binary" use="optional">
@@ -488,7 +491,7 @@
                     </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
-        </xs:attribute>
+        </xs:attribute>    
     </xs:attributeGroup>
     <xs:attributeGroup name="ifOpt">
         <xs:attribute name="if" type="xs:string" use="optional" form="unqualified"/>
@@ -509,7 +512,7 @@
                     </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
-        </xs:attribute>
+        </xs:attribute>    
     </xs:attributeGroup>
     <xs:attributeGroup name="numericOpt">
         <xs:attribute name="numeric" use="optional" default="no">
@@ -618,7 +621,7 @@
                     </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
-        </xs:attribute>
+        </xs:attribute>    
     </xs:attributeGroup>
     <xs:attributeGroup name="typeOpt">
         <xs:attribute name="type" type="xs:QName" use="optional" form="unqualified"/>

--- a/resources/schema/conf.xsd
+++ b/resources/schema/conf.xsd
@@ -1,0 +1,1509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+    Schema for eXist Configuration file conf.xml
+    
+    TODO: Remove optional attributes in favour of well defined/named parent elements
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="2.6.0">
+
+    <xs:include schemaLocation="schema-version-type.xsd"/>
+
+    <!-- Shared types -->
+    <xs:simpleType name="yes_no">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Memory / disk size expressed as a number followed by an optional SI suffix.
+         Accepts: plain bytes (e.g. "65536"), kilobytes ("64K"), megabytes ("48M"),
+         gigabytes ("2G"), terabytes ("1T") — case-insensitive suffix.
+         The special value "-1" is accepted to signal "disabled" or "unlimited". -->
+    <xs:simpleType name="memorySizeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="-1|[0-9]+[KkMmGgTt]?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:element name="parameter">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the parameter
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="value" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The value of the parameter
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="description" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Optional human-readable description of the parameter's purpose.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="enabled" type="yes_no" default="yes">
+                <xs:annotation>
+                    <xs:documentation>
+                        Set to "no" to disable this parameter without removing it from the configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    
+    <!-- Root element -->
+    <xs:element name="exist">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="db-connection">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="startup" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="triggers" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="trigger" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:sequence>
+                                                                <xs:element ref="parameter" minOccurs="0" maxOccurs="unbounded"/>
+                                                            </xs:sequence>
+                                                            <xs:attribute name="class" type="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The full class name of the trigger implementation
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="enabled" type="yes_no" default="yes">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        Set to "no" to disable this trigger without removing it from the configuration.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="pool">
+                                <xs:complexType>
+                                    <xs:attribute name="max" type="xs:positiveInteger" default="20">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Maximum number of connections allowed.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="min" type="xs:positiveInteger" default="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Minimum number of connections to keep alive.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="sync-period" type="xs:integer" default="120000">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines how often the database will flush its
+                                                internal buffers to disk. The sync thread will interrupt
+                                                normal database operation after the specified number of
+                                                milliseconds and write all dirty pages to disk.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="wait-before-shutdown" type="xs:integer" default="120000">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines how long the database instance will wait for running
+                                                operations to complete before it forces a shutdown. Forcing
+                                                a shutdown may leave the db in an unclean state and may
+                                                trigger a recovery run on restart.
+                                                <p/>
+                                                Setting wait-before-shutdown="-1" means that the server will
+                                                wait for all threads to return, no matter how long it takes.
+                                                No thread will be killed.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="query-pool" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="max-stack-size" type="xs:integer" default="5">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Maximum number of queries in the query-pool.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="size" type="xs:integer" default="128">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Number of copies of the same query kept in the query-pool.
+                                                Value "-1" effectively disables caching. Queries cannot be shared
+                                                by threads, each thread needs a private copy of a query.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="recovery">
+                                <xs:complexType>
+                                    <xs:attribute name="enabled" type="yes_no" default="yes">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                If this attribute is set to yes, automatic recovery is enabled.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="group-commit" type="yes_no" default="no">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                If set to "yes", eXist will not sync the journal file
+                                                immediately after every transaction commit. Instead,
+                                                it will wait until the current file buffer (32kb)
+                                                is really full. This can speed up eXist on some systems
+                                                where a file sync is an expensive operation (mainly windows
+                                                XP; not necessary on Linux). However, group-commit="yes"
+                                                will increase the risk of an already committed
+                                                operation being rolled back after a database crash.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="journal-dir" type="xs:string" default="webapp/WEB-INF/data">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This attribute sets the directory where journal files are to be
+                                                written. If no directory is specified, the default path is to
+                                                the data directory.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="size" type="memorySizeType" default="100M">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This attributes sets the maximum allowed size of the journal
+                                                file. Once the journal reaches this limit, a checkpoint will be
+                                                triggered and the journal will be cleaned. However, the database
+                                                waits for running transactions to return before processing this
+                                                checkpoint. In the event one of these transactions writes a lot
+                                                of data to the journal file, the file will grow until the
+                                                transaction has completed. Hence, the size limit is not enforced
+                                                in all cases.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="sync-on-commit" type="yes_no" default="no">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This attribute determines whether or not to protect the journal
+                                                during operating system failures. That is, it determines whether
+                                                the database forces a file-sync on the journal after every
+                                                commit.
+                                                <p/>
+                                                If this attribute is set to "yes", the journal is protected
+                                                against operating system failures. However, this will slow
+                                                performance - especially on Windows systems.
+                                                <p/>
+                                                If set to "no", eXist will rely on the operating system to flush
+                                                out the journal contents to disk. In the worst case scenario,
+                                                in which there is a complete system failure, some committed
+                                                transactions might not have yet been written to the journal,
+                                                and so will be rolled back.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="force-restart" type="yes_no" default="no">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Try to restart the db even if crash recovery failed. This is
+                                                dangerous because there might be corruptions inside the
+                                                data files. The transaction log will be cleared, all locks removed
+                                                and the db reindexed.
+                                                <p/>
+                                                Set this option to "yes" if you need to make sure that the db is
+                                                online, even after a fatal crash. Errors encountered during recovery
+                                                are written to the log files. Scan the log files to see if any problems
+                                                occurred.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="consistency-check" type="yes_no" default="yes">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                If set to "yes", a consistency check will be run on the database
+                                                if an error was detected during crash recovery. This option requires
+                                                force-restart to be set to "yes", otherwise it has no effect.
+                                                <p/>
+                                                The consistency check outputs a report to the directory {files}/sanity
+                                                and if inconsistencies are found in the db, it writes an emergency
+                                                backup to the same directory.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="watchdog">
+                                <xs:complexType>
+                                    <xs:attribute name="output-size-limit" type="xs:integer">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This attribute limits the size of XML fragments constructed
+                                                using XQuery, and thus sets the maximum amount of main memory a
+                                                query is allowed to use. This limit is expressed as the maximum
+                                                number of nodes allowed for an in-memory DOM tree. The purpose
+                                                of this option is to avoid memory shortages on the server in
+                                                cases where users are allowed to run queries that produce very
+                                                large output fragments.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="query-timeout" type="xs:integer">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This attribute sets the maximum amount of time (expressed in
+                                                milliseconds) that the query can take before it is killed..
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="cacheShrinkThreshold" type="xs:integer" default="10000">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The minimum number of pages that must be read from a
+                                    cache between check intervals to be not considered for
+                                    shrinking. This is a measure for the "load" of the cache. Caches
+                                    with high load will never be shrinked. A negative value means that
+                                    shrinkage will not be performed.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="cacheSize" type="memorySizeType" default="48M">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The maximum amount of memory to use for database page buffers.
+                                    Each database file has an associated page buffer for B+-tree and
+                                    data pages. However, the memory specified via cacheSize is shared
+                                    between all page buffers. It represents an absolute maximum, which
+                                    would be occupied if all page buffers were completely full.
+                                    <p/>
+                                    The cacheSize should typically not be more than half of the size of
+                                    the JVM heap size (set by the JVM -Xmx parameter). It can be larger
+                                    if you have a large-memory JVM (usually a 64bit JVM)
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="checkMaxCacheSize" type="xs:string" default="true">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Specifies whether eXist should check the max cache size on startup
+                                    and reduce it if it is too large.
+                                    <p/>
+                                    This value should normally be set to true.
+                                    <p/>
+                                    Only set this value to false if:
+                                    <p/>
+                                    a) You know what you are doing!
+                                    b) You have a JVM with tons of memory (typically using a 64-bit
+                                    JVM, which is the scenario this setting is intended for).
+                                    c) You are really sure you've complied with a) and b) above.
+                                    <p/>
+                                    Setting this value to false may cause memory issues which may lead to
+                                    database corruptions, since it disables the automated max cache size
+                                    checks! You have been warned! ;-)
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="collectionCache" type="memorySizeType" default="24M">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Maximum amount of memory (in megabytes) to use for collection caches.
+                                    Memory calculation is just approximate. If your collections are very
+                                    different in size, it might be possible that the actual amount of
+                                    memory used exceeds the specified limit. You should thus be careful
+                                    with this setting.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="database" type="xs:string" default="@database@">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Selects a database backend. Currently, "native" is the only valid setting.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="doc-ids" type="xs:string" default="default">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    TODO
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="files" type="xs:string" default="webapp/WEB-INF/data">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Path to the directory where database files are stored.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="free_mem_min" type="xs:integer" default="5">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    TODO
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="minDiskSpace" type="memorySizeType" default="128M">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The amount of disk space (in megabytes) which should be available for
+                                    the database to continue operations. If free disk space goes below
+                                    the configured limit, eXist-db will flush all buffers to disk and
+                                    switch to read-only mode in order to prevent potential data loss.
+                                    Set the limit large enough to allow all pending operations to
+                                    complete. Set to -1 to disable. The default is 1 gigabyte.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="nodesBuffer" type="xs:integer" default="-1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Size of the temporary buffer used by eXist for caching index
+                                    data while indexing a document. If set to -1, eXist will use the
+                                    entire free memory to buffer index entries and will flush the
+                                    cache once the memory is full.
+                                    <p/>
+                                    If set to a value > 0, the buffer will be fixed to the given size.
+                                    The specified number corresponds to the number of nodes the
+                                    buffer can hold, in thousands. Usually, a good default could be
+                                    nodesBuffer="1000".
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="pageSize" type="xs:integer" default="4096">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The size of one page on the disk. This is the smallest unit
+                                    transferred from and to the database files. Should be a multiple of
+                                    the operating system's file system page size (usually 4096).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="posix-chown-restricted" type="xs:boolean" default="true">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+                                    <p/>
+                                    When posix-chown-restricted="true" (the default) then:
+                                    1. Only a superuser process can change the user ID of the file.
+                                    2. A non-superuser process can change the group ID of the file
+                                    if the process owns the file (the effective user ID equals
+                                    the user ID of the file), and group equals either the
+                                    effective group ID of the process or one of the
+                                    process’s supplementary group IDs.
+                                    This means that when posix-chown-restricted="true", you can’t change
+                                    the user ID of your files. You can change the group ID of files that
+                                    you own, but only to groups that you belong to.
+                                    <p/>
+                                    When posix-chown-restricted="false" you can change the user ID of
+                                    any file that you own, effectively "giving away the file" to
+                                    another user. Such a setting has negative security implications,
+                                    further details can be seen in the "Rationale" section for the
+                                    chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+                                    See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="preserve-on-copy" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    When copying Collections and Documents within the database, the
+                                    default (`false`), is not to preserve their attributes
+                                    (modification time, mode, user-id, group-id, and ACL).
+                                    <p/>
+                                    <b>NOTE:</b> Not preserving attributes, is inline with both the GNU and
+                                    BSD `cp` commands, and therefore expected behaviour; The target
+                                    Collection or Document is created following the rules of the
+                                    target parent, and the effective user and their umask.
+                                    <p/>
+                                    Setting preserve-on-copy="true" changes the default behaviour
+                                    so that the target Collection or Document of a copy, has the same
+                                    attributes as the source.
+                                    <p/>
+                                    The preserve-on-copy setting can be overridden on a case-by-case
+                                    basis by setting the `preserve` flag to either `true` or `false`
+                                    when calling xmldb:copy(), or via any other API that supports copy.
+                                    Omitting the preserve flag when calling a copy operation, implies
+                                    the behaviour that is set in this configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="lock-manager">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="lock-table">
+                                <xs:complexType>
+                                    <xs:attribute name="disabled" type="xs:boolean" default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                                                and allows reporting on database locking via JMX.
+                                                <p/>
+                                                <b>NOTE:</b> Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                                                have finished testing their system to ensure correct operation, they may wish to disable
+                                                this in production to ensure the absolute best performance.
+                                                <p/>
+                                                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                                                or (legacy) `exist.locktable.disable`.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="trace-stack-depth" type="xs:nonNegativeInteger" default="0">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                                                operation. These frames are visible from JMX reporting.
+                                                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                                                events are written to the locks.log file.
+                                                <p/>
+                                                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                                                or (legacy) `exist.locktable.trace.stack.depth`.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="document">
+                                <xs:complexType>
+                                    <xs:attribute name="use-path-locks" type="xs:boolean" default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Set to true to have documents participate in the same hierarchical
+                                                path based locking strategy as Collections.
+                                                <p/>
+                                                This has a performance and concurrency impact, but will ensure
+                                                that you cannot have deadlocks between Collections and Documents.
+                                                <p/>
+                                                <b>NOTE:</b> in future this will likely be set to `true` by default.
+                                                <p/>
+                                                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="paths-multi-writer" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set to true to enable Multi-Writer/Multi-Reader semantics for
+                                    the database Collection/Document Hierarchy as opposed to the default (false)
+                                    for Single-Writer/Multi-Reader.
+                                    <p/>
+                                    <b>NOTE:</b> Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+                                    through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+                                    Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+                                    It is highly recommended that users leave this as the default setting. For more information, see:
+                                    "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+                                    https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+                                    <p/>
+                                    This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+                                    or (legacy) `exist.lockmanager.paths-multiwriter`.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="upgrade-check" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Used by developers for diagnosing illegal lock upgrade issues. When enabled
+                                    checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+                                    are enabled. When an illegal upgrade is detected a LockException is thrown.
+                                    Such behaviour will likely corrupt any database writes, and should only be
+                                    used by developers when debugging database issues.
+                                    <p/>
+                                    This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                                    or (legacy) `exist.lockmanager.upgrade.check`.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="warn-wait-on-read-for-write" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Used by developers for diagnosing lock performance issues. When enabled
+                                    checks for detecting when a thread wants to acquire the WRITE_LOCK
+                                    but another thread holds the READ_LOCK are enabled. When such operations
+                                    are detected a log message is written to locks.log at WARN level.
+                                    <p/>
+                                    This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                                    or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="repository">
+                    <xs:complexType>
+                        <xs:attribute name="root" type="xs:string" default="/db/apps">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The root collection for deployed applications. Application collections will be saved below
+                                    this collection.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="binary-manager">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="cache">
+                                <xs:complexType>
+                                    <xs:attribute name="class" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines the class to use to Cache InputStreams when reading binary documents
+                                                from the database or from a read once source such as a http request (e.g. request:get-data()).
+                                                There are currently three options available:
+
+                                                - org.exist.util.io.FileFilterInputStreamCache
+                                                Default. Temporary binary streams are cached to a temporary file on disk.
+
+                                                - org.exist.util.io.MemoryMappedFileFilterInputStreamCache
+                                                Temporary binary streams are cached to a temporary file on disk which
+                                                has been mapped into memory. Faster than FileFilterInputStreamCache.
+                                                Not reliable on Windows platforms.
+
+                                                - org.exist.util.io.MemoryFilterInputStreamCache
+                                                Temporary binary streams are cached in memory.
+                                                This is the fastest approach. However it can result in out of memory
+                                                errors under heavy load or if using large binary files.
+
+                                                Where temporary files are used, they will be deleted after use.
+                                                However, due to a bug in the JVM on Windows platforms, temporary files cannot be deleted, so instead
+                                                they are re-cycled and re-used and deleted if the database is restarted.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="indexer">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="modules">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="module" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="id" type="xs:string" default="ngram-index">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Unique identifier for the module
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="class" type="xs:string" default="org.exist.indexing.impl.NGramIndex">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The full class name of the module implementation
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="file" type="xs:string" default="ngram.dbx">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The index file name
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="connectionTimeout" type="xs:integer" default="10000">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The connection timeout
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="flushAfter" type="xs:integer" default="300">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Number of documents to index before the n-gram index
+                                                            is flushed to disk. Higher values improve throughput
+                                                            at the cost of memory during bulk ingest.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="n" type="xs:integer" default="3">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The n in n-gram: the number of characters per token.
+                                                            Default 3 produces trigrams, which support efficient
+                                                            substring searches via the ngram:contains() function.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="buffer" type="xs:integer" default="32">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The buffer size
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="enabled" type="yes_no" default="yes">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Set to "no" to disable this index module without removing it from the configuration.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="index">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="create" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="path" type="xs:string" use="optional">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            XPath expression to the node to index (e.g. "//book/title").
+                                                            Mutually exclusive with qname.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="qname" type="xs:string" use="optional">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Qualified name of the element or attribute to index
+                                                            (e.g. "title" or "@id"). Mutually exclusive with path.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="type" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            XQuery/XML Schema type to cast node values to when indexing
+                                                            (e.g. "xs:integer", "xs:dateTime"). Determines the comparison
+                                                            semantics available on this index.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="caseSensitive" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should equality comparisons between strings be case-sensitive or
+                                    insensitive: "yes" or "no".
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="index-depth" type="xs:integer" default="5">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Defines the maximum nesting depth of nodes which will be indexed
+                                    in the DOM index. Nodes below the specified nesting depth will
+                                    not be indexed in the DOM file. This has only an effect when
+                                    retrieving query results or for some types of XPath subexpressions,
+                                    like equality comparisons.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="preserve-whitespace-mixed-content" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Preserve the white space inside a mixed content node: "yes" or "no".
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="suppress-whitespace" default="both">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should leading or trailing whitespace be removed from a text node?
+                                    Set to "leading", "trailing", "both" or "none".
+                                    Changing the parameter will only have an effect on newly loaded
+                                    files, not old ones.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="leading"/>
+                                    <xs:enumeration value="trailing"/>
+                                    <xs:enumeration value="both"/>
+                                    <xs:enumeration value="none"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="scheduler">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="job" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element ref="parameter" minOccurs="0" maxOccurs="unbounded"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="type" use="optional" default="user">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The type of the job to schedule. Must be either "system"
+                                                or "user".
+
+                                                system - System jobs require the database to be in a consistent state.
+                                                All database operations will be stopped until the method returns or
+                                                throws an exception. Any exception will be caught and a warning written to
+                                                the log.
+
+                                                user - User jobs may be scheduled at any time and may be mutually exclusive
+                                                or non-exclusive
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="startup"/>
+                                                <xs:enumeration value="system"/>
+                                                <xs:enumeration value="user"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="name" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The name of the job
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="class" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                If the job is written in Java then this should be the name of the
+                                                class that extends either org.exist.storage.SystemTask or
+                                                org.exist.scheduler.UserJavaJob
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="xquery" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                If the job is written in XQuery (not suitable for system jobs) then
+                                                this should be a path to an XQuery stored in the database. e.g.
+                                                /db/myCollection/myJob.xql
+                                                XQuery job's will be launched under the guest account initially,
+                                                although the running XQuery may switch permissions through
+                                                calls to xmldb:login().
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="cron-trigger" type="xs:string"
+                                        use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                To define a firing pattern for the Job using Cron style syntax
+                                                use this attribute otherwise for a periodic job use the period
+                                                attribute. Not applicable to startup jobs.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="unschedule-on-exception" type="yes_no" use="optional" default="yes">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Boolean: yes/true, no/false. Default: true. If true and an exception is
+                                                encountered then the job is unscheduled for further execution until a
+                                                restart; otherwise, the exception is ignored.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="period" type="xs:positiveInteger" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Can be used to define an explicit period for firing the job instead
+                                                of a Cron style syntax. The period should be in milliseconds.
+                                                Not applicable to startup jobs.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="delay" type="xs:long" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Can be used with a period to delay the start of a job. If unspecified jobs
+                                                will start as soon as the database and scheduler are initialised.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="repeat" type="xs:integer" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Can be used with a period to define for how many periods a job should be
+                                                executed. If unspecified jobs will repeat for every period indefinitely.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="enabled" type="yes_no" default="yes">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Set to "no" to disable this job without removing it from the configuration.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="parser">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="xml" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="features" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="feature" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:attribute name="name" use="required" type="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the feature flag
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="value" use="required" type="xs:boolean">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The value of the feature flag
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="enabled" type="yes_no" default="yes">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        Set to "no" to disable this feature flag without removing it from the configuration.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="html-to-xml" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="properties" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:attribute name="name" use="required" type="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the property
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="value" use="required" type="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The value of the property
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="enabled" type="yes_no" default="yes">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        Set to "no" to disable this property without removing it from the configuration.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="features" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="feature" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:attribute name="name" use="required" type="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the feature flag
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="value" use="required" type="xs:boolean">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The value of the feature flag
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                            <xs:attribute name="enabled" type="yes_no" default="yes">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        Set to "no" to disable this feature flag without removing it from the configuration.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:attribute>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="class" use="required" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The Java classname of a parser which implements org.xml.sax.XMLReader
+                                                and is capable of parsing HTML and emitting an XML Sax Stream.
+                                                <p/>
+                                                Whichever library you use for this, it must be present on the classpath
+                                                perhaps the best way to do this is to place it into $EXIST_HOME/lib/user
+                                                <p/>
+                                                Examples include:
+                                                - org.codelibs.nekohtml.parsers.SAXParser
+                                                The Cyber NekoHTML parser from https://sourceforge.net/projects/nekohtml/
+                                                <p/>
+                                                - org.ccil.cowan.tagsoup.Parser
+                                                The TagSoup parser from http://home.ccil.org/~cowan/XML/tagsoup/
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="serializer">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="custom-filter" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="class" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The class implementing the custom filter
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="add-exist-id" default="none">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    For debugging: add an exist:id attribute to every element, showing
+                                    the internal node identifier (as a long int) assigned to this node.
+                                    Possible values are: "none", "element", "all". "all" displays the
+                                    node of every element node; "element" displays the id only for the
+                                    root nodes of the returned XML fragments.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="all"/>
+                                    <xs:enumeration value="element"/>
+                                    <xs:enumeration value="none"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="compress-output" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the output be compressed when serializing documents?
+                                    Sometimes useful with remote clients.
+                                    Remember to add a statement like this to your client code:
+                                    service.setProperty("compress-output", "yes");
+                                    to uncompress the retrieved result in the client too.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="omit-xml-declaration" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the XML Declaration for a document be serialized
+                                    if it is present?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="omit-original-xml-declaration" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the original persisted XML Declaration for a document be serialized
+                                    if it is present?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="output-doctype" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the Doctype Declaration for a document be serialized
+                                    if it is present?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="enable-xinclude" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the database expand XInclude tags by default?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="enable-xsl" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the database evaluate XSL processing instructions
+                                    when serializing documents?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="indent" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Should the serializer pretty-print (indent) XML?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="match-tagging-attributes" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Matches for attribute values can also be tagged using the character
+                                    sequence "||" to demarcate the matching text string. Since this
+                                    changes the content of the attribute value, the feature is disabled
+                                    by default.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="match-tagging-elements" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The database can highlight matches in the text content of a node by
+                                    tagging the matching text string with &lt;exist:match&gt;. Clearly, this
+                                    only works for XPath expressions using the some indexes.
+                                    <p/>
+                                    Set the parameter to "yes" to enable this feature.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="transformer">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The attribute name
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="value" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The attribute value
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="type" default="string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The attribute type
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="boolean"/>
+                                                <xs:enumeration value="integer"/>
+                                                <xs:enumeration value="string"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="class" type="xs:string" default="org.apache.xalan.processor.TransformerFactoryImpl">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The name of the class that implements javax.xml.transform.TransformerFactory
+                                    <p/>
+                                    for Saxon (XSLT 2.0 support):
+                                    - "net.sf.saxon.TransformerFactoryImpl"
+                                    <p/>
+                                    for Xalan (XSLT 1.0 support):
+                                    - "org.apache.xalan.processor.TransformerFactoryImpl"
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="caching" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set to "no" to disable XSL stylesheet caching.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="validation">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="entity-resolver">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="catalog" minOccurs="1" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="uri" type="xs:string" default="webapp/WEB-INF/catalog.xml">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The URI pointing to the according catalog
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="grammar-cache">
+                                <xs:complexType>
+                                    <xs:attribute name="size">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specifies the maximum number of entries the cache may contain.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:integer">
+                                                <xs:minInclusive value="-1"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="expire">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The time (in seconds) after which an unused grammar should
+                                                expire and be removed from the grammar pool.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:integer">
+                                                <xs:minInclusive value="-1"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="mode" default="auto">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    should XML source files be validated against a schema or DTD before
+                                    storing them? The setting is passed to the XML parser. The actual
+                                    effects depend on the parser you use. eXist comes with Xerces which
+                                    can validate against both: schemas and DTDs.
+                                    <p/>
+                                    Possible values: "yes", "no", "auto". "auto" will leave validation
+                                    to the parser.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="auto"/>
+                                    <xs:enumeration value="no"/>
+                                    <xs:enumeration value="yes"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+
+
+                <xs:element name="xquery">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="builtin-modules">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="module" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element ref="parameter" minOccurs="0" maxOccurs="unbounded"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="class" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Fully-qualified class name of the Java module implementation.
+                                                            The class must implement org.exist.xquery.Module.
+                                                            Mutually exclusive with src.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="uri" type="xs:anyURI">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Namespace URI that this module is bound to
+                                                            (e.g. "http://exist-db.org/xquery/math").
+                                                            Must match the URI declared inside the module source.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="src" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Path to an XQuery library module source file.
+                                                            Used instead of class for XQuery-implemented modules.
+                                                            Mutually exclusive with class.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="enabled" type="yes_no" default="yes">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Set to "no" to disable this module without removing it from the configuration.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="enable-java-binding" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    eXist supports calls to arbitrary Java methods from within
+                                    XQuery. Setting to "yes" might introduce a security risk.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="disable-deprecated-functions" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set to "yes" to disable deprecated functions
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="enable-query-rewriting" type="yes_no" default="yes">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set to "yes" to enable the new query-rewriting optimizer. This
+                                    is work in progress and may lead to incorrect queries. Use at your
+                                    own risk.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="backwardCompatible" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set to "yes" to enable backward compatibility (untyped argument
+                                    checks for instance)
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="raise-error-on-failed-retrieval" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set to "yes" if a call to doc(), xmldb:document(), collection() or
+                                    xmldb:xcollection() should raise an error (FODC0002) when an
+                                    XML resource cannot be retrieved.
+                                    Set to "no" (default) if such a call should return an empty sequence
+                                    when the resource cannot be retrieved.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="enforce-index-use" default="strict">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Controls whether range indexes must be defined on all collections
+                                    in the context sequence before the query engine will use them.
+                                    "strict" — the index is used only if every collection in the context
+                                    defines it; otherwise the engine falls back to a full scan.
+                                    "always" — the engine uses an available index even if only some
+                                    collections define it; results may be incomplete if others lack the index.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="always"/>
+                                    <xs:enumeration value="strict"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="xupdate">
+                    <xs:complexType>
+                        <xs:attribute name="allowed-fragmentation" type="xs:integer" default="5">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Defines the maximum number of page splits allowed within a document
+                                    before a defragmentation run will be triggered.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="enable-consistency-checks" type="yes_no" default="no">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    For debugging only. If the parameter is set to "yes", a consistency
+                                    check will be run on every modified document after every XUpdate
+                                    request. It checks if the persistent DOM is complete and all
+                                    pointers in the structural index point to valid storage addresses
+                                    containing valid nodes.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="growth-factor" type="xs:integer" default="20">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Percentage by which the DOM storage file grows when it needs to
+                                    be expanded to accommodate new data. A value of 20 means the
+                                    file grows by 20% of its current size each time it is extended.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="saxon">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Load this configuration into Saxon
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:attribute name="configuration-file" type="xs:string">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    If `configuration-file` is a relative filename, it is relative to $EXIST_HOME/etc
+                                    (this is the same directory as the eXist-db configuration file `conf.xml`)
+                                    `configuration-file` may also be an absolute filename.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="rpc-server">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Defines the RPC server backend specific options used to process the requests.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="content-file">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Defines per document specific cache settings.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="in-memory-size" type="xs:integer" default="4096">
+                                     <xs:annotation>
+                                         <xs:documentation>
+                                             Defines the maximum amount of bytes stored in memory for each content file instance.
+                                         </xs:documentation>
+                                     </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="content-file-pool">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Defines content file pool handling.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="size" type="xs:integer" default="-1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines the maximum content file pool size. If this size is exhausted an error is thrown. Using -1 sets no limit.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="max-idle" type="xs:integer" default="5">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines the maximum amount of idle pool entries that will not be removed for later reuse.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="vector-models" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Global vector embedding model registry. When vector-field or vector:embed
+                            omits model-path, the registry supplies path and dimension. Add models
+                            here to use custom or additional embedding models.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="model" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="id" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>Model identifier (e.g. all-MiniLM-L6-v2)</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="path" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>Local path or HuggingFace/API URL</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="dimension" type="xs:positiveInteger" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>Embedding dimension (default 384)</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="schemaVersion" type="schemaVersionType" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/resources/schema/controller-config.xsd
+++ b/resources/schema/controller-config.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           xmlns:exist="http://exist.sourceforge.net/NS/exist"
+           elementFormDefault="qualified"
+           targetNamespace="http://exist.sourceforge.net/NS/exist"
+           version="1.1.1">
+  <xs:include schemaLocation="schema-version-type.xsd"/>
+  <xs:element name="configuration">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="exist:forward"/>
+        <xs:element ref="exist:root"/>
+      </xs:choice>
+      <xs:attribute name="schemaVersion" type="exist:schemaVersionType" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="forward">
+    <xs:complexType>
+      <xs:attribute name="pattern" use="required" type="xs:string"/>
+      <xs:attribute name="servlet" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="server-name" use="optional" type="xs:string"/>
+      <xs:attribute name="path" use="required" type="xs:anyURI"/>
+      <xs:attribute name="pattern" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/resources/schema/descriptor.xsd
+++ b/resources/schema/descriptor.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+    Schema for eXist WebApp Descriptor Configuration file descriptor.xml
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.2.1">
+    <xs:include schemaLocation="schema-version-type.xsd"/>
+    <xs:element name="xquery-app">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="allow-source">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="xquery" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="path" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="maps">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="map" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="path" type="xs:string"/>
+                                    <xs:attribute name="view" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="request-replay-log" type="xs:boolean" default="false"/>
+            <xs:attribute name="filtered" type="xs:boolean" default="false"/>
+            <xs:attribute name="schemaVersion" type="schemaVersionType" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/resources/schema/expath-pkg.xsd
+++ b/resources/schema/expath-pkg.xsd
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:pkg="http://expath.org/ns/pkg"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    elementFormDefault="qualified"
+    targetNamespace="http://expath.org/ns/pkg"
+    version="1.1.1">
+    
+    <xs:annotation>
+        <xs:documentation>A schema for EXPath Packaging (i.e. <code>expath-pkg.xml</code>) file as per the <a href="http://expath.org/spec/pkg">EXPath Packaging System - Candidate Module 9 May 2012'</a> specification.</xs:documentation>
+        <xs:appinfo>
+            <dcterms:title>Schema for EXPath Packaging</dcterms:title>
+            <dcterms:created>2013-11-03T11:36:19.343+01:00</dcterms:created>
+            <dcterms:creator>Adam Retter</dcterms:creator>
+        </xs:appinfo>
+    </xs:annotation>
+    
+    <xs:element name="package">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="title" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>A simple description of the package for humans.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="home" minOccurs="0" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>A URI to find more information about the package.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="pkg:dependencyType">
+                    <xs:annotation>
+                        <xs:documentation>A dependency of this package.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:group ref="pkg:component" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:anyURI" use="required">
+                <xs:annotation>
+                    <xs:documentation>The name of the package. A package is named using an IRI, as defined by <a href="file:///Users/aretter/Desktop/expath-pkg-spec.html#rfc3987">[RFC 3987]</a>, excepted any IRI using the file: scheme (most frequent choices are http: and urn: scheme URIs). Note that the definition of IRI excludes relative references.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="abbrev" type="xs:NCName" use="required"/>
+            <xs:attribute name="version" type="pkg:semVer2Type" use="required"/>
+            <xs:attribute name="spec" type="xs:string" use="required" fixed="1.0">
+                <xs:annotation>
+                    <xs:documentation>The version of the packaging specification the package conforms to.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:group name="component">
+        <xs:annotation>
+            <xs:documentation>The standard component kinds supported by this specification, and how they contribute to the package descriptor document type. Every component has the same basic information: it associates a public URI to a specific file within the content directory. The file element contains a path, relative to the package content directory. Both elements in a component are of type anyURI.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="xslt" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>An XSLT file is associated a public import URI. This is the URI to use in an XSLT import instruction (aka xsl:import) to import the XSLT file provided in the package.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xquery" type="pkg:xqueryType">
+                    <xs:annotation>
+                        <xs:documentation>An XQuery library module is referenced by its namespace URI. Thus the xquery element associates a namespace URI to an XQuery file. An importing module just need to use an import statement of the form <code>import module namespace xx = "&lt;namespace-uri&gt;'"</code>;. An XQuery main module is associated a public URI. Usually an XQuery package will provide functions through library modules, but in some cases one can want to provide main modules as well.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xproc" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>An XProc pipeline, like an XSLT stylesheet, is associated a public import URI, aimed to be used in an XProc p:import statement.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xsd" type="pkg:xsdType">
+                    <xs:annotation>
+                        <xs:documentation>An XML schema can be imported using its target namespace. It is not possible to set several files as several sources for the schema. If the schema is spread over multiple files, there must be one top-level file that includes the other files.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="rng" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>A RelaxNG schema, like an XSLT stylesheet, is associated a public import URI, aimed to be used in the include element for an RNG schema.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="rnc" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>A RelaxNG schema, like an XSLT stylesheet, is associated a public import URI, aimed to be used in an import directive for an RNC schema.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="schematron" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>A Schematron schema is associated a public URI.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="nvdl" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>An NVDL script is associated a public URI.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dtd" type="pkg:dtdType">
+                    <xs:annotation>
+                        <xs:documentation>A DTD file is associated a public URI.</xs:documentation>
+                    </xs:annotation>                    
+                </xs:element>
+                <xs:element name="resource" type="pkg:resourceType">
+                    <xs:annotation>
+                        <xs:documentation>A resource file is associated a public URI. This can be any kind of file. It has to be used in accordance to its content. For instance accessing a text file through fn:unparsed-text() is correct, while using fn:doc() is not (it will raise an error because it parses the content as XML).</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    
+
+    <xs:complexType name="xqueryType">
+        <xs:attribute name="namespace" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation>The URI of the Namespace of the XQuery Library Module.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:import-uri" use="optional">
+            <xs:annotation>
+                <xs:documentation>The URI of where the XQuery Main Module should be accessible from.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:file" use="required"/>
+        <xs:assert test="(@namespace and not(@import-uri)) or (not(@namespace) and @import-uri)">
+            <xs:annotation>
+                <xs:documentation>The @namespace and @import-uri attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+    </xs:complexType>
+    
+    <xs:complexType name="xsdType">
+        <xs:attribute name="namespace" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation>The URI of the Target Namespace of the XML Schema.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:import-uri" use="optional">
+            <xs:annotation>
+                <xs:documentation>The import-uri can be used to define a schema location for this schema component. This can be useful for schema without target namespace, or for some specific usages, like when using xs:redefine.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:file" use="required"/>
+        <xs:assert test="(@namespace and not(@import-uri)) or (not(@namespace) and @import-uri)">
+            <xs:annotation>
+                <xs:documentation>The @namespace and @import-uri attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+    </xs:complexType>
+    
+    <xs:complexType name="dtdType">
+        <xs:attribute name="public-id" type="pkg:dtdFormalPublicIdentifierType" use="optional"/>
+        <xs:attribute name="system-id" type="xs:anyURI"/>
+        <xs:attribute ref="pkg:file"/>
+    </xs:complexType>
+    
+    <xs:simpleType name="dtdFormalPublicIdentifierType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value=".+\/\/.+\/\/.+\/\/.+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:complexType name="resourceType">
+        <xs:attribute name="public-uri" type="xs:anyURI"/>
+        <xs:attribute ref="pkg:file"/>
+    </xs:complexType>
+
+    <xs:complexType name="importUriFromFileType">
+        <xs:attribute ref="pkg:import-uri" use="required"/>
+        <xs:attribute ref="pkg:file" use="required"/>
+    </xs:complexType>
+    
+    <xs:attribute name="import-uri" type="xs:anyURI"/>
+    
+    <xs:attribute name="file" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>Contains a path, relative to the package content directory.</xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    
+    <xs:complexType name="dependencyType">
+        <xs:annotation>
+            <xs:documentation>Must specify a 'package' or 'processor', and one of 'versions', 'semver', or ('semver-min' and/or 'semver-max').</xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="package" type="xs:anyURI" use="optional"/>
+        <xs:attribute name="processor" type="xs:string" use="optional"/>
+
+        <xs:attribute name="versions" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The exact set of acceptable versions for the secondary package, separated by spaces.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="semver" type="pkg:semVer2OrSemVer2TemplateType"/>
+        <xs:attribute name="semver-min" type="pkg:semVer2OrSemVer2TemplateType"/>
+        <xs:attribute name="semver-max" type="pkg:semVer2OrSemVer2TemplateType"/>
+        
+        <xs:assert test="(@package and not(@processor)) or (not(@package) and @processor)">
+            <xs:annotation>
+                <xs:documentation>The @package and @processor attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+        
+        <xs:assert test="(@versions and not(@semver) and not(@semver-min) and not(@semver-max)) or (not(@versions) and @semver and not(@semver-min) and not(@semver-max)) or (not(@versions) and not(@semver) and (@semver-min or @semver-max))">
+            <xs:annotation>
+                <xs:documentation>The @versions, @semver, and (@semver-min and/or @semver-max) attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+    </xs:complexType>
+    
+    <xs:simpleType name="semVer2OrSemVer2TemplateType">
+        <xs:union memberTypes="pkg:semVer2Type pkg:semVer2TemplateType"/>
+    </xs:simpleType>
+    
+    <xs:simpleType name="semVer2Type">
+        <xs:annotation>
+            <xs:documentation>A <a href="https://semver.org/">SemVer 2.0.0</a> version number.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <xs:simpleType name="semVer2TemplateType">
+        <xs:annotation>
+            <xs:documentation>A subpart (i.e. only the major version, or the major and the minor versions, or the major, the minor and the patch version) of a <a href="https://semver.org/">SemVer 2.0.0</a> version number. For instance 1.9 is a valid SemVer template (because it does not have any patch number).</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+</xs:schema>

--- a/resources/schema/mime-types.xsd
+++ b/resources/schema/mime-types.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Schema for eXist Mime Type Configuration file mime-types.xml
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.2.1">
+    <xs:include schemaLocation="schema-version-type.xsd"/>
+    <xs:element name="mime-types">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="mime-type" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="description" type="xs:string"/>
+                            <xs:element name="extensions">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:pattern value="(\.[a-zA-Z0-9][a-zA-Z0-9.\-]*)+(,\.[a-zA-Z0-9][a-zA-Z0-9.\-]*)*"/>
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:pattern value="[a-z0-9]+\/[a-z0-9\.\-]+([\+][a-z0-9]+)?"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="type">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="binary"/>
+                                    <xs:enumeration value="xml"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+			<xs:attribute name="default-mime-type">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[a-z0-9]+\/[a-z0-9\.\-]+([\+][a-z0-9]+)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+			</xs:attribute>
+            <xs:attribute name="default-resource-type">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="binary"/>
+                        <xs:enumeration value="xml"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="schemaVersion" type="schemaVersionType" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/resources/schema/schema-version-type.xsd
+++ b/resources/schema/schema-version-type.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Shared type for the optional schemaVersion attribute on canonical config
+    instance documents. xs:include this file (it declares no targetNamespace,
+    so it is included as a chameleon component — see W3C XML Schema Part 1,
+    4.2.3) from each native schema that wants a schemaVersion attribute.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           version="1.0.0">
+
+    <xs:simpleType name="schemaVersionType">
+        <xs:annotation>
+            <xs:documentation>Native XSD semver; mirrors the paired schema's xs:schema/@version (not eXist product version). See schema/README.md.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(0|[1-9]\d*)(\.(0|[1-9]\d*)){0,2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/resources/schema/security-manager.xsd
+++ b/resources/schema/security-manager.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+    xmlns:cnf="http://exist-db.org/Configuration"
+    xmlns:db="http://docbook.org/ns/docbook"
+    elementFormDefault="qualified"
+    targetNamespace="http://exist-db.org/Configuration"
+    version="2.0.0">
+    
+    <xs:annotation>
+        <xs:documentation>
+            <db:info>
+                <db:title>LDAP Security Manager Schema</db:title>
+                <db:date>2012-01-14</db:date>
+                <db:author>
+                    <db:personname>
+                        <db:firstname>Adam</db:firstname>
+                        <db:surname>Retter</db:surname>
+                    </db:personname>
+                    <db:email>adam@exist-db.org</db:email>
+                </db:author>
+            </db:info>
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:element name="security-manager" type="cnf:securityManagerType"/>
+    
+    <xs:complexType name="securityManagerType">
+        <xs:sequence>
+            <xs:element ref="cnf:authentication-entry-point"/>
+            <xs:element ref="cnf:events" minOccurs="0"/>
+            <xs:element ref="cnf:realm" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="last-account-id" type="xs:int"/>
+        <xs:attribute name="last-group-id" type="xs:int"/>
+        <xs:attribute name="version" type="xs:decimal" fixed="2.0"/>
+    </xs:complexType>
+    
+    <xs:element name="authentication-entry-point" type="cnf:authenticationEntryPointType"/>
+    
+    <xs:simpleType name="authenticationEntryPointType">
+        <xs:restriction base="xs:anyURI">
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:element name="events" type="cnf:eventsType"/>
+    
+    <xs:complexType name="eventsType">
+        <xs:attribute name="script-uri" type="xs:anyURI"/>
+    </xs:complexType>
+    
+    <xs:element name="realm" type="cnf:realmType"/>
+
+    <xs:complexType name="realmType">
+        <xs:sequence>
+            <xs:any namespace="http://exist-db.org/Configuration" processContents="lax"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="cnf:realmTypeId"/>
+        <xs:anyAttribute processContents="lax"/>
+    </xs:complexType>
+    
+    <xs:simpleType name="realmTypeId">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+</xs:schema>

--- a/resources/schema/server.xsd
+++ b/resources/schema/server.xsd
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Schema for eXist Server Configuration file server.xml
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
+    <xs:simpleType name="yes_no">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:attributeGroup name="service">
+        <xs:attribute name="enabled" type="yes_no" default="yes"/>
+        <xs:attribute name="context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The context path of the service. Specify an url-pattern as for a servlet-mapping.
+                    Example: /xmlrpc/* forwards all paths beginning with /xmlrpc to the xmlrpc service
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="param">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="service">
+        <xs:sequence>
+            <xs:element ref="param" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="service"/>
+    </xs:complexType>
+    <xs:element name="server">
+        <xs:annotation>
+            <xs:documentation>
+                Configures the stand-alone server: the stand-alone server is a minimal
+                webserver with just three services enabled by default:
+                WebDAV, XML-RPC, REST
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="listener" minOccurs="1" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element ref="param" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:attribute name="protocol" type="xs:string"/>
+                        <xs:attribute name="port" type="xs:integer"/>
+                        <xs:attribute name="host" type="xs:string" use="optional"/>
+                        <xs:attribute name="address" type="xs:string" use="optional"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="webdav" type="service"/>
+                <xs:element name="xmlrpc" type="service"/>
+                <xs:element name="rest" type="service"/>
+                <xs:element name="servlet" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attributeGroup ref="service"/>
+                        <xs:attribute name="class" type="xs:string"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="filter" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element ref="param" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:attribute name="enabled" type="yes_no" default="yes"/>
+                        <xs:attribute name="path" type="xs:string"/>
+                        <xs:attribute name="class" type="xs:string"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="forwarding">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="root" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Define a forwarding for requests to the server root, i.e.
+                                        if you access the server without specifying a path
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="destination" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The destination path to which the request will be
+                                                forwarded.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="forward" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Define URL forwardings
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="path" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Requests to the given path will be forwarded
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="destination" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The destination path to which the request will be
+                                                forwarded
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/resources/schema/users.xsd
+++ b/resources/schema/users.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+    Schema for eXist Users Authentication file /db/system/users.xml
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
+    <xs:attribute name="last-id" type="xs:integer"/>
+    <xs:element name="auth">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="groups">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="group" minOccurs="2" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>Must be at least guest and dba groups, hence minOccurs=2</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string"/>
+                                    <xs:attribute name="id" type="xs:integer"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute ref="last-id"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="users">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="user" minOccurs="1" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>Must contain the admin user at least, hence minOccurs=1</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="group" minOccurs="1" maxOccurs="unbounded" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation>Each user must be in at least one group, hence minOccurs=1</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:string"/>
+                                    <xs:attribute name="uid" type="xs:integer"/>
+                                    <xs:attribute name="password" type="xs:string"/>
+                                    <xs:attribute name="digest-password" type="xs:string"/>
+                                    <xs:attribute name="home" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute ref="last-id"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:decimal" default="1.0"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
## Summary

- Resolve known eXist/EXPath grammars for `POST /api/editor/validate`, preferring `$EXIST_HOME/schema/` (exist#6528) and falling back to synced copies under `resources/schema/` (eXide#842).
- Cover namespaced configs (`collection.xconf`, `controller-config`, `expath-pkg`, `security-manager`) and no-namespace roots (`conf.xml`, `descriptor`, `mime-types`, `users`, `server`), plus `xsi:schemaLocation` / `noNamespaceSchemaLocation` when they point at a known grammar or an absolute `file:`/`/db/` URI.
- Validate with `validation:jaxv-report` + XSD 1.1 (interim until catalog-based jaxp works against native grammars — exist#6686). Response includes `grammar` (`native`|`bundled`|`instance`|`none`) and `schema` for observability.
- Keep `resources/schema/catalog.xml` for tooling / a future catalog path; document deprecation of the bundled copies.

Closes #842.

## Test plan

- [x] `xst package install local-files build/eXide-4.0.1.xar --force --config .existdb.json`
- [x] Smoke: collection.xconf + mime-types return `grammar: "native"` on `existdb/existdb:latest`
- [x] `npx cypress run --spec cypress/e2e/xml_validate_spec.cy.js` (7/7)
- [ ] CI green on `existdb/existdb:latest`
- [ ] Optional: server without `$EXIST_HOME/schema/` still validates via bundled XSDs (`grammar: "bundled"`)